### PR TITLE
Add index endpoint to translations controller

### DIFF
--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,12 +1,25 @@
 # frozen_string_literal: true
 
 class TranslationsController < ApplicationController
+  
+  def index
+    render json: all_translations, include: params[:include], status: :ok
+  end
+  
   def show
     redirect
   end
 
   private
 
+  def all_translations
+    if params['filter']
+      Translation.is_published(params['filter']['is_published'])
+    else
+      Translation.all
+    end
+  end
+      
   def redirect
     translation = Translation.find(params[:id])
     redirect_to translation.s3_uri, status: :found

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -6,21 +6,29 @@ class TranslationsController < ApplicationController
   end
 
   def show
-    redirect
+    @translation = Translation.find(params[:id])
+    if @translation.is_published
+      redirect
+    else
+      render_not_found
+    end
   end
 
   private
 
   def all_translations
-    if params['filter']
-      Translation.is_published(params['filter']['is_published'])
-    else
-      Translation.all
-    end
+    Translation.where(is_published: true)
+  end
+
+  def render_not_found
+    @translation.errors.add(:message, 'Translation not found.')
+    render json: @translation,
+           status: :not_found,
+           adapter: :json_api,
+           serializer: ActiveModel::Serializer::ErrorSerializer
   end
 
   def redirect
-    translation = Translation.find(params[:id])
-    redirect_to translation.s3_uri, status: :found
+    redirect_to @translation.s3_uri, status: :found
   end
 end

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TranslationsController < ApplicationController
-
   def index
     render json: all_translations, include: params[:include], status: :ok
   end

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class TranslationsController < ApplicationController
-  
+
   def index
     render json: all_translations, include: params[:include], status: :ok
   end
-  
+
   def show
     redirect
   end
@@ -19,7 +19,7 @@ class TranslationsController < ApplicationController
       Translation.all
     end
   end
-      
+
   def redirect
     translation = Translation.find(params[:id])
     redirect_to translation.s3_uri, status: :found


### PR DESCRIPTION
To allow clients to download list of translations, filtered by is_published for now, and include other things that it cares about.