### PR TITLE
Attributes

### DIFF
--- a/app/models/attribute.rb
+++ b/app/models/attribute.rb
@@ -4,4 +4,6 @@ class Attribute < ActiveRecord::Base
   belongs_to :resource
 
   has_many :translated_attributes
+
+  validates :key, format: { with: /\A[[:alpha:]]+(_[[:alpha:]]+)*\z/ }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -4,6 +4,7 @@ class Resource < ActiveRecord::Base
   belongs_to :system
   has_many :translations
   has_many :pages
+  has_many :resource_attributes, class_name: 'Attribute'
 
   scope :system_name, lambda { |name|
     t = System.arel_table

--- a/app/serializers/resource_serializer.rb
+++ b/app/serializers/resource_serializer.rb
@@ -9,4 +9,10 @@ class ResourceSerializer < ActiveModel::Serializer
   has_many :translations
   has_many :latest_translations, key: 'latest-translations'
   has_many :pages
+
+  def attributes(*args)
+    hash = super
+    object.resource_attributes.each { |r| hash["attr_#{r.key}"] = r.value }
+    hash
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -127,9 +127,9 @@ Translation.find_or_create_by(resource: is_there_god, language: english, version
 
 AccessCode.find_or_create_by(code: 123_456)
 
-Attribute.find_or_create_by(resource: kgp, key: 'Banner Image', value: 'this is a location')
-attribute = Attribute.find_or_create_by(resource: kgp, key: 'translate me', value: 'base language', is_translatable: true)
+Attribute.find_or_create_by(resource: kgp, key: 'Banner_Image', value: 'this is a location')
+attribute = Attribute.find_or_create_by(resource: kgp, key: 'translate_me', value: 'base language', is_translatable: true)
 
-Attribute.find_or_create_by(resource: satisfied, key: 'Another Attribute', value: 'blah blah blah')
+Attribute.find_or_create_by(resource: satisfied, key: 'Another_Attribute', value: 'blah blah blah')
 
 TranslatedAttribute.find_or_create_by(parent_attribute: attribute, translation: german_kgp, value: 'german attribute')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -130,4 +130,6 @@ AccessCode.find_or_create_by(code: 123_456)
 Attribute.find_or_create_by(resource: kgp, key: 'Banner Image', value: 'this is a location')
 attribute = Attribute.find_or_create_by(resource: kgp, key: 'translate me', value: 'base language', is_translatable: true)
 
+Attribute.find_or_create_by(resource: satisfied, key: 'Another Attribute', value: 'blah blah blah')
+
 TranslatedAttribute.find_or_create_by(parent_attribute: attribute, translation: german_kgp, value: 'german attribute')

--- a/spec/acceptance/resources_controller_spec.rb
+++ b/spec/acceptance/resources_controller_spec.rb
@@ -47,5 +47,15 @@ resource 'Resources' do
       expect(status).to be(200)
       expect(JSON.parse(response_body)['included'].count).to be(3)
     end
+
+    it 'has custom attributes', document: false do
+      do_request
+
+      expect(status).to be(200)
+      attrs = JSON.parse(response_body)['data']['attributes']
+      expect(attrs.size).to be(6)
+      expect(attrs['attr-banner image']).to eq('this is a location')
+      expect(attrs['attr-translate me']).to eq('base language')
+    end
   end
 end

--- a/spec/acceptance/resources_controller_spec.rb
+++ b/spec/acceptance/resources_controller_spec.rb
@@ -54,8 +54,8 @@ resource 'Resources' do
       expect(status).to be(200)
       attrs = JSON.parse(response_body)['data']['attributes']
       expect(attrs.size).to be(6)
-      expect(attrs['attr-banner image']).to eq('this is a location')
-      expect(attrs['attr-translate me']).to eq('base language')
+      expect(attrs['attr-banner-image']).to eq('this is a location')
+      expect(attrs['attr-translate-me']).to eq('base language')
     end
   end
 end

--- a/spec/models/attributes_spec.rb
+++ b/spec/models/attributes_spec.rb
@@ -5,9 +5,25 @@ require 'rails_helper'
 describe Attribute do
   it 'resource/key combination must be unique' do
     expect do
-      Attribute.create(resource_id: 1,
-                       key: 'Banner Image',
-                       value: 'bar')
+      Attribute.create!(resource_id: 1,
+                        key: 'Banner_Image',
+                        value: 'bar')
     end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it 'key cannot end in underscore' do
+    expect do
+      Attribute.create!(resource_id: 1,
+                        key: 'roger_',
+                        value: 'test')
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'key cannot have spaces' do
+    expect do
+      Attribute.create!(resource_id: 1,
+                        key: 'roger the dog',
+                        value: 'test')
+    end.to raise_error(ActiveRecord::RecordInvalid)
   end
 end


### PR DESCRIPTION
1. Show resource attributes as attributes instead of a relationship
2. Force attribute keys to be in format blah_blah_blah