### PR TITLE
provide resource dereferencing via the manifest xml

### DIFF
--- a/manifest/content.xml
+++ b/manifest/content.xml
@@ -13,10 +13,10 @@
 
   <!--
     Image Content - WIP
-      resource:  REQUIRED - image source
+      resource:  REQUIRED - the resource id listed in the manifest
       alignment: - (left|right|center) DEFAULT( center )
   -->
-  <image resource="{{image_uri}}" align="center"/>
+  <image resource="{{resource_id}}" align="center"/>
 
   <!--
     Button - WIP

--- a/manifest/manifest.xml
+++ b/manifest/manifest.xml
@@ -49,4 +49,12 @@
     <page id="{{event_id}}" src="{{page_xml_uri}}"/>
     <page id="{{event_id}}" src="{{page_xml_uri}}"/>
   </pages>
+
+  <!--
+    Resources - REQUIRED
+      list of all resources used within this tract
+  -->
+  <resources>
+    <resource id="{{id_or_filename}}" src="{{sha256.jpg}}" />
+  </resources>
 </manifest>

--- a/manifest/manifest.xml
+++ b/manifest/manifest.xml
@@ -18,7 +18,7 @@
   background-color:        Application background color, tract:page background color
                             DEFAULT( rgba(255, 255, 255, 1) )
 
-  background-image:       Application background image
+  background-image:       Application background image, references a resource listed in the manifest
                             DEFAULT( none )
 
   background-image-align: (top|bottom|left|right|center)
@@ -27,7 +27,7 @@
 <manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
           xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
           background-color="{{rgba}}"
-          background-image="{{image reference}}"
+          background-image="{{resource_id}}"
           background-image-align="repeat"
           primary-color="{{rgba}}"
           primary-text-color="{{rgba}}"
@@ -55,6 +55,6 @@
       list of all resources used within this tract
   -->
   <resources>
-    <resource id="{{id_or_filename}}" src="{{sha256.jpg}}" />
+    <resource id="{{filename.jpg}}" src="{{sha256.jpg}}" />
   </resources>
 </manifest>

--- a/manifest/tract.xml
+++ b/manifest/tract.xml
@@ -14,7 +14,7 @@
   background-color:        tract:page background color
                             DEFAULT( rgba(255, 255, 255, 0) ) /* transparent */
 
-  background-image:       tract:page background image.
+  background-image:       tract:page background image, references a resource listed in the manifest
                             DEFAULT( none )
 
   background-image-align: (top|bottom|left|right|center|repeat)
@@ -23,7 +23,7 @@
 <page xmlns="http://mobile-content-api.cru.org/xmlns/tract"
       xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
       background-color="{{rgba}}"
-      background-image="{{image reference}}"
+      background-image="{{resource_id}}"
       background-image-align="center">
 
   <!--


### PR DESCRIPTION
This will allow page xml to be a bit more readable and not require rewriting resources when publishing.
This also provides a quick list of all resources used within a tool.