### PR TITLE
Schema: Update listener to be listeners

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -45,6 +45,11 @@
             <xs:pattern value="[a-zA-Z0-9_\-]+" />
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="listenerValues">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z0-9_\-]+(,[a-zA-Z0-9_\-]+)*" />
+        </xs:restriction>
+    </xs:simpleType>
 
     <!-- element nodes -->
     <!--

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -41,14 +41,12 @@
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="listenerValue">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="xs:token">
             <xs:pattern value="[a-zA-Z0-9_\-]+" />
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="listenerValues">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_\-]+(,[a-zA-Z0-9_\-]+)*" />
-        </xs:restriction>
+    <xs:simpleType name="listenersType">
+        <xs:list itemType="content:listenerValue" />
     </xs:simpleType>
 
     <!-- element nodes -->

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -57,8 +57,11 @@
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
         <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
-        <!-- listeners: event_ids that trigger display of this page -->
-        <xs:attribute name="listeners" type="content:listenerValues" use="optional" />
+        <xs:attribute name="listeners" type="content:listenerValues" use="optional">
+            <xs:annotation>
+                <xs:documentation>event_ids that trigger this page</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <!--

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -128,8 +128,8 @@
         <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
         <!-- hidden: DEFAULT( false ) whether this card is hidden. hidden cards can still be displayed if they have a listener that is triggered. -->
         <xs:attribute name="hidden" type="xs:boolean" use="optional" />
-        <!-- listener: an event_id that triggers display of this card -->
-        <xs:attribute name="listener" type="content:listenerValue" use="optional" />
+        <!-- listeners: event_ids that trigger display of this card -->
+        <xs:attribute name="listeners" type="content:listenerValues" use="optional" />
     </xs:complexType>
 
     <!-- Call to Action (next page arrow / text) -->
@@ -158,7 +158,8 @@
                 <xs:element ref="tract:paragraph" />
             </xs:choice>
         </xs:sequence>
-        <xs:attribute name="listener" type="content:listenerValue" use="required" />
+        <xs:attribute name="listeners" type="content:listenerValues" use="required" />
+        <xs:attribute name="dismiss-listeners" type="content:listenerValues" use="required" />
     </xs:complexType>
 
     <!-- Paragraph - Vertical stack of content with margin/padding between each item -->

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -57,6 +57,8 @@
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
         <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
+        <!-- listeners: event_ids that trigger display of this page -->
+        <xs:attribute name="listeners" type="content:listenerValues" use="optional" />
     </xs:complexType>
 
     <!--

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -57,7 +57,7 @@
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
         <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
-        <xs:attribute name="listeners" type="content:listenerValues" use="optional">
+        <xs:attribute name="listeners" type="content:listenersType" use="optional">
             <xs:annotation>
                 <xs:documentation>event_ids that trigger this page</xs:documentation>
             </xs:annotation>
@@ -134,7 +134,7 @@
         <!-- hidden: DEFAULT( false ) whether this card is hidden. hidden cards can still be displayed if they have a listener that is triggered. -->
         <xs:attribute name="hidden" type="xs:boolean" use="optional" />
         <!-- listeners: event_ids that trigger display of this card -->
-        <xs:attribute name="listeners" type="content:listenerValues" use="optional" />
+        <xs:attribute name="listeners" type="content:listenersType" use="optional" />
     </xs:complexType>
 
     <!-- Call to Action (next page arrow / text) -->
@@ -163,8 +163,8 @@
                 <xs:element ref="tract:paragraph" />
             </xs:choice>
         </xs:sequence>
-        <xs:attribute name="listeners" type="content:listenerValues" use="required" />
-        <xs:attribute name="dismiss-listeners" type="content:listenerValues" use="required" />
+        <xs:attribute name="listeners" type="content:listenersType" use="required" />
+        <xs:attribute name="dismiss-listeners" type="content:listenersType" use="required" />
     </xs:complexType>
 
     <!-- Paragraph - Vertical stack of content with margin/padding between each item -->


### PR DESCRIPTION
The purpose of this change is to be able to listen for multiple events for the same object. This allows us to name our events based on their source and not the target listener. This means we may have multiple buttons/events that end up at the same listener, but they will show up as distinct events within Google Analytics.

listeners are defined as a space separated list of event names.

I also added dismiss-listeners for modals to the tract schema

Sample xml:
```xml
<page
    listeners="post-followup circles" />
```
```xml
<card
    listeners="new-followup followup" />
```
```xml
<modal
    listeners="followup-modal event2"
    dismiss-listeners="dismiss-followup-modal event3" />
```