### PR TITLE
Image scale type and align

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -10,6 +10,33 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="imageScaleType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="fit">
+                <xs:annotation>
+                    <xs:documentation>Scale image to fit the UI size without cropping any of the image
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fill">
+                <xs:annotation>
+                    <xs:documentation>Scale image to completely fill the UI, cropping if necessary</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fill-x">
+                <xs:annotation>
+                    <xs:documentation>Scale image to match the width of the UI, cropping if necessary</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="fill-y">
+                <xs:annotation>
+                    <xs:documentation>Scale image to match the height of the UI, cropping if necessary
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="fullAlignValue">
         <xs:restriction base="xs:string">
             <xs:enumeration value="start" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -150,11 +150,15 @@
     <!--
         Image
             resource:  REQUIRED - the resource id listed in the manifest
-            align:     (start|end|center) DEFAULT( center )
     -->
     <xs:complexType name="image">
+        <xs:annotation>
+            <xs:documentation>This is an image content type. The image is rendered with a width matching the width of
+                whatever container it is contained in. This is done to provide the most consistent image size experience
+                across devices of varying screen sizes and densities.
+            </xs:documentation>
+        </xs:annotation>
         <xs:attribute name="resource" type="xs:string" use="required" />
-        <xs:attribute name="align" type="content:horizontalAlignValue" use="optional" />
     </xs:complexType>
 
     <!-- Button -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -36,6 +36,54 @@
             </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="imageGravity">
+        <xs:annotation>
+            <xs:documentation>This type defines align attributes for how an image should be aligned before applying the
+                scale type. It is possible to have 1 align type specified for each axis (e.g. "start top").
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="center">
+                        <xs:annotation>
+                            <xs:documentation>The image should be centered in it's container.</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="start">
+                        <xs:annotation>
+                            <xs:documentation>The start edge of the image should be aligned to the start edge of the
+                                container. The start edge is the left edge if left to right languages, and right edge in
+                                right to left languages.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="end">
+                        <xs:annotation>
+                            <xs:documentation>The end edge of the image should be aligned to the end edge of the
+                                container. The end edge is the right edge if left to right languages, and left edge in
+                                right to left languages.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="top">
+                        <xs:annotation>
+                            <xs:documentation>The top edge of the image should be aligned to the top edge of the
+                                container.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="bottom">
+                        <xs:annotation>
+                            <xs:documentation>The bottom edge of the image should be aligned to the bottom edge of the
+                                container.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
 
     <xs:simpleType name="fullAlignValue">
         <xs:restriction base="xs:string">

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -29,6 +29,12 @@
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
+        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines how we should scale the background image. This defaults to fill.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
         <xs:attribute name="navbar-color" type="content:colorValue" use="optional">
             <xs:annotation>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -29,13 +29,13 @@
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
-        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional">
+        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional" default="center">
             <xs:annotation>
                 <xs:documentation>This defines how we align the background image. This defaults to center.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional">
+        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional" default="fill">
             <xs:annotation>
                 <xs:documentation>This defines how we should scale the background image. This defaults to fill.
                 </xs:documentation>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -29,13 +29,18 @@
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
+        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines how we align the background image. This defaults to center.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional">
             <xs:annotation>
                 <xs:documentation>This defines how we should scale the background image. This defaults to fill.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
         <xs:attribute name="navbar-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This defines the color of the application navigation bar for this tool. This defaults

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -129,8 +129,18 @@
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <!-- background-image: DEFAULT( none ) -->
         <xs:attribute name="background-image" type="xs:string" use="optional" />
-        <!-- background-image-align: (top|bottom|left|right|center|repeat) DEFAULT( center ) -->
-        <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
+        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines how we align the background image. This defaults to center.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines how we should scale the background image. This defaults to fill-x.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <!-- hidden: DEFAULT( false ) whether this card is hidden. hidden cards can still be displayed if they have a listener that is triggered. -->
         <xs:attribute name="hidden" type="xs:boolean" use="optional" />
         <!-- listeners: event_ids that trigger display of this card -->

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -6,8 +6,6 @@
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
 
-    <!-- Value definitions -->
-
     <!-- element nodes -->
     <!--
         Page node
@@ -27,9 +25,6 @@
 
             background-image:       tract:page background image.
                                     DEFAULT( none )
-
-            background-image-align: (top|bottom|left|right|center|repeat)
-                                    DEFAULT( center )
     -->
     <xs:complexType name="page">
         <xs:sequence>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -140,13 +140,13 @@
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <!-- background-image: DEFAULT( none ) -->
         <xs:attribute name="background-image" type="xs:string" use="optional" />
-        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional">
+        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional" default="center">
             <xs:annotation>
                 <xs:documentation>This defines how we align the background image. This defaults to center.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional">
+        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional" default="fill-x">
             <xs:annotation>
                 <xs:documentation>This defines how we should scale the background image. This defaults to fill-x.
                 </xs:documentation>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -56,7 +56,18 @@
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
         <xs:attribute name="background-image" type="xs:string" use="optional" />
-        <xs:attribute name="background-image-align" type="content:fullAlignValue" use="optional" />
+        <xs:attribute name="background-image-align" type="content:imageGravity" use="optional" default="center">
+            <xs:annotation>
+                <xs:documentation>This defines how we align the background image. This defaults to center.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional" default="fill-x">
+            <xs:annotation>
+                <xs:documentation>This defines how we should scale the background image. This defaults to fill-x.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="listeners" type="content:listenersType" use="optional">
             <xs:annotation>
                 <xs:documentation>event_ids that trigger this page</xs:documentation>


### PR DESCRIPTION
sample xml:

```xml
<manifest
    background-image="image.png"
    background-image-align="bottom start"
    background-image-scale-type="fit" />
```
```xml
<page
    background-image="image.png"
    background-image-align="bottom"
    background-image-scale-type="fill-x" />
```
```xml
<card
    background-image="image.png"
    background-image-align="center"
    background-image-scale-type="fill-x" />
```
