### PR TITLE
Card colors

### DIFF
--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:manifest="https://mobile-content-api.cru.org/xmlns/manifest" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:manifest="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     attributeFormDefault="unqualified" elementFormDefault="qualified"
     targetNamespace="https://mobile-content-api.cru.org/xmlns/manifest">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/tract" schemaLocation="tract.xsd" />
 
     <xs:complexType name="manifest">
         <xs:all>
@@ -55,6 +57,9 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
+        <!-- Import any external groups of attributes we want to support -->
+        <xs:attributeGroup ref="tract:manifest" />
     </xs:complexType>
 
     <xs:complexType name="page">

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -63,6 +63,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="card-text-color" type="content:colorValue" use="optional">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the text color for cards on this page. This will default to the
+                    text-color set for the page.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="card-background-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This defines the default background color for any card that appears on this page. This
@@ -138,7 +145,6 @@
                 <xs:element ref="tract:form" />
             </xs:choice>
         </xs:sequence>
-        <!-- background-color: DEFAULT( inherited from page ) -->
         <xs:attribute name="background-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This sets the background color of this card. This will default to the
@@ -157,6 +163,13 @@
         <xs:attribute name="background-image-scale-type" type="content:imageScaleType" use="optional" default="fill-x">
             <xs:annotation>
                 <xs:documentation>This defines how we should scale the background image. This defaults to fill-x.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="text-color" type="content:colorValue" use="optional">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the text-color for this card. This will default to the
+                    card-text-color set for the page.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -63,6 +63,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="card-background-color" type="content:colorValue" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines the default background color for any card that appears on this page. This
+                    defaults to the tract:card-background-color defined on the manifest.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="listeners" type="content:listenersType" use="optional">
             <xs:annotation>
                 <xs:documentation>event_ids that trigger this page</xs:documentation>
@@ -132,7 +139,13 @@
             </xs:choice>
         </xs:sequence>
         <!-- background-color: DEFAULT( inherited from page ) -->
-        <xs:attribute name="background-color" type="content:colorValue" use="optional" />
+        <xs:attribute name="background-color" type="content:colorValue" use="optional">
+            <xs:annotation>
+                <xs:documentation>This sets the background color of this card. This will default to the
+                    card-background-color for this page.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <!-- background-image: DEFAULT( none ) -->
         <xs:attribute name="background-image" type="xs:string" use="optional" />
         <xs:attribute name="background-image-align" type="content:imageGravity" use="optional" default="center">
@@ -220,6 +233,25 @@
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
+
+    <!-- attributes -->
+    <xs:attribute name="card-background-color" type="content:colorValue" />
+
+    <!-- attribute groups -->
+    <xs:attributeGroup name="manifest">
+        <xs:annotation>
+            <xs:documentation>This attribute group is the set of attributes that can appear on the manifest node in the
+                manifest xml.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute ref="tract:card-background-color" use="optional">
+            <xs:annotation>
+                <xs:documentation>This defines the default background color for any cards that appear in pages contained
+                    by this manifest. This defaults to the manifest background-color.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
 
     <!-- base elements -->
     <xs:element name="page" type="tract:page" />


### PR DESCRIPTION
This PR adds card-background-color and card-text-color attributes

Sample new XML:

```xml
<manifest
    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract"
    tract:card-background-color="rgba(255,255,255,1)" />
```
```xml
<page
    card-background-color="rgba(255,255,255,1)"
    card-text-color="rgba(90,90,90,1)" />
```
```xml
<card
    text-color="rgba(90,90,90,1)" />
```
