### PR TITLE
Track the tool code and language in the published manifest

### DIFF
--- a/lib/s3_util.rb
+++ b/lib/s3_util.rb
@@ -33,6 +33,9 @@ class S3Util
     @document = Nokogiri::XML::Document.parse(@translation.resource.manifest)
     manifest_node = load_or_create_manifest_node
 
+    manifest_node['code'] = @translation.resource.abbreviation
+    manifest_node['language'] = @translation.language.code
+
     pages_node = Nokogiri::XML::Node.new('pages', @document)
     resources_node = Nokogiri::XML::Node.new('resources', @document)
 

--- a/lib/s3_util.rb
+++ b/lib/s3_util.rb
@@ -33,8 +33,7 @@ class S3Util
     @document = Nokogiri::XML::Document.parse(@translation.resource.manifest)
     manifest_node = load_or_create_manifest_node
 
-    manifest_node['code'] = @translation.resource.abbreviation
-    manifest_node['language'] = @translation.language.code
+    set_code_and_language(manifest_node)
 
     pages_node = Nokogiri::XML::Node.new('pages', @document)
     resources_node = Nokogiri::XML::Node.new('resources', @document)
@@ -63,6 +62,11 @@ class S3Util
     manifest_node = XmlUtil.xpath_namespace(@document, 'manifest').first
     insert_translated_name(manifest_node)
     manifest_node
+  end
+
+  def set_code_and_language(manifest_node)
+    manifest_node['code'] = @translation.resource.abbreviation
+    manifest_node['language'] = @translation.language.code
   end
 
   def insert_translated_name(manifest_node)

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -26,6 +26,16 @@
                 </xs:complexType>
             </xs:element>
         </xs:all>
+        <xs:attribute name="code" type="xs:token" use="optional">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the short code for this tool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="language" type="xs:language" use="optional">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the language this tool is for.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="primary-color" type="content:colorValue" use="optional" />
         <xs:attribute name="primary-text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />


### PR DESCRIPTION
I want to include the resource code and language in published manifest xml files. This should be a simple change, but not sure how to write a spec to test it.

expected output manifest xml:
```xml
<manifest
    code="kgp"
    language="en" />
```