### PR TITLE
GT-360: Support i18n-id replacement for attribute nodes 

### DIFF
--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -83,7 +83,7 @@ class Translation < ActiveRecord::Base
   def onesky_translated_page_attributes(xml, phrases, strict)
     XmlUtil.translatable_node_attrs(xml).each do |attribute|
       phrase_id = attribute.value
-      new_name = attribute.name.slice('-i18n-id')
+      new_name = attribute.name.gsub("-i18n-id", "")
       translated_phrase = phrases[phrase_id]
 
       if translated_phrase.present?

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -3,6 +3,7 @@
 require 's3_util'
 require 'xml_util'
 
+# rubocop:disable ClassLength
 class Translation < ActiveRecord::Base
   belongs_to :resource
   belongs_to :language
@@ -56,8 +57,15 @@ class Translation < ActiveRecord::Base
   def onesky_translated_page(page_id, strict)
     page = Page.find(page_id)
     phrases = download_translated_phrases(page.filename)
-
     xml = Nokogiri::XML(page_structure(page_id))
+
+    xml = onesky_translated_page_content(xml, phrases, strict)
+    xml = onesky_translated_page_attributes(xml, phrases, strict)
+
+    xml.to_s
+  end
+
+  def onesky_translated_page_content(xml, phrases, strict)
     XmlUtil.translatable_nodes(xml).each do |node|
       phrase_id = node['i18n-id']
       translated_phrase = phrases[phrase_id]
@@ -69,6 +77,10 @@ class Translation < ActiveRecord::Base
       end
     end
 
+    xml
+  end
+
+  def onesky_translated_page_attributes(xml, phrases, strict)
     XmlUtil.translatable_node_attrs(xml).each do |attribute|
       phrase_id = attribute.value
       new_name = attribute.name.slice('-i18n-id')
@@ -82,7 +94,7 @@ class Translation < ActiveRecord::Base
       end
     end
 
-    xml.to_s
+    xml
   end
 
   def page_structure(page_id)

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -69,6 +69,19 @@ class Translation < ActiveRecord::Base
       end
     end
 
+    XmlUtil.translatable_node_attrs(xml).each do |attribute|
+      phrase_id = attribute.value
+      new_name = attribute.name.slice('-i18n-id')
+      translated_phrase = phrases[phrase_id]
+
+      if translated_phrase.present?
+        attribute.name = new_name
+        attribute.value = translated_phrase
+      elsif strict
+        raise Error::TextNotFoundError, "Translated phrase not found: ID: #{phrase_id}, base text: #{attribute.value}"
+      end
+    end
+
     xml.to_s
   end
 

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -83,7 +83,7 @@ class Translation < ActiveRecord::Base
   def onesky_translated_page_attributes(xml, phrases, strict)
     XmlUtil.translatable_node_attrs(xml).each do |attribute|
       phrase_id = attribute.value
-      new_name = attribute.name.gsub("-i18n-id", "")
+      new_name = attribute.name.gsub('-i18n-id', '')
       translated_phrase = phrases[phrase_id]
 
       if translated_phrase.present?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,9 @@ page_13_structure = '<?xml version="1.0" encoding="UTF-8" ?>
       <content:text>These four points explain how to enter into a personal relationship with God and
         experience the life for which you were created.
       </content:text>
+      <content:button type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">
+        <content:text>Label</content:text>
+      </content:button>
     </content:form>
   </hero>
 </page>'

--- a/lib/xml_util.rb
+++ b/lib/xml_util.rb
@@ -5,6 +5,10 @@ module XmlUtil
     xml.xpath('//content:text[@i18n-id]')
   end
 
+  def self.translatable_node_attrs(xml)
+    xml.xpath("//@*[contains(name(),'-i18n-id')]")
+  end
+
   def self.xml_filename_sha(data)
     "#{filename_sha(data)}.xml"
   end

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -236,6 +236,7 @@
                 <xs:documentation>This attribute defines the url to open for "url" buttons.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="url-i18n-id" type="xs:string" use="optional" />
         <xs:attribute name="color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This attribute determines the color of the button. This defaults to the primary-color

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -3,16 +3,17 @@
 require 'rails_helper'
 
 describe Translation do
+  # rubocop:disable LineLength
   let(:page_name) { '13_FinalPage.xml' }
   let(:element_one_id) { 'f9894df9-df1d-4831-9782-345028c6c9a2' }
   let(:element_two_id) { '9deda19f-c3ee-42ed-a1eb-92423e543352' }
+  let(:element_three_id) { '9deda19f-c3ee-42ed-a1eb-92423e543353' }
   let(:phrase_one) { 'This is a German phrase' }
   let(:phrase_two) { 'another phrase in German' }
   let(:phrase_three) { 'https://www.bible.com/' }
-  let(:phrases) { "{ \"#{element_one_id}\":\"#{phrase_one}\", \"#{element_two_id}\":\"#{phrase_two}\" }" }
+  let(:phrases) { "{ \"#{element_one_id}\":\"#{phrase_one}\", \"#{element_two_id}\":\"#{phrase_two}\", \"#{element_three_id}\":\"#{phrase_three}\"}" }
   let(:phrase_one_element) { "<content:text i18n-id=\"#{element_one_id}\">#{phrase_one}</content:text>" }
   let(:phrase_two_element) { "<content:text i18n-id=\"#{element_two_id}\">#{phrase_two}</content:text>" }
-  # rubocop:disable LineLength
   let(:phrase_three_element) { "<content:button type=\"url\" url=\"#{phrase_three}\"><content:text>Label</content:text></content:button>" }
 
   # rubocop:enable LineLength

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -8,9 +8,14 @@ describe Translation do
   let(:element_two_id) { '9deda19f-c3ee-42ed-a1eb-92423e543352' }
   let(:phrase_one) { 'This is a German phrase' }
   let(:phrase_two) { 'another phrase in German' }
+  let(:phrase_three) { 'https://www.bible.com/' }
   let(:phrases) { "{ \"#{element_one_id}\":\"#{phrase_one}\", \"#{element_two_id}\":\"#{phrase_two}\" }" }
   let(:phrase_one_element) { "<content:text i18n-id=\"#{element_one_id}\">#{phrase_one}</content:text>" }
   let(:phrase_two_element) { "<content:text i18n-id=\"#{element_two_id}\">#{phrase_two}</content:text>" }
+  # rubocop:disable LineLength
+  let(:phrase_three_element) { "<content:button type=\"url\" url=\"#{phrase_three}\"><content:text>Label</content:text></content:button>" }
+
+  # rubocop:enable LineLength
 
   context 'builds a translated page from resource page' do
     let(:result) do
@@ -24,6 +29,10 @@ describe Translation do
     it 'includes translated phrases' do
       includes_translated_phrases
     end
+
+    it 'includes translated attributes' do
+      includes_translated_attributes
+    end
   end
 
   context 'builds a translated page from custom page' do
@@ -36,6 +45,9 @@ describe Translation do
     end
     it 'includes translated phrases' do
       includes_translated_phrases
+    end
+    it 'includes translated attributes' do
+      includes_translated_attributes
     end
   end
 
@@ -208,5 +220,9 @@ describe Translation do
   def includes_translated_phrases
     expect(result.include?(phrase_one_element)).to be_truthy
     expect(result.include?(phrase_two_element)).to be_truthy
+  end
+
+  def includes_translated_attributes
+    expect(result.include?(phrase_three_element)).to be_truthy
   end
 end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -14,7 +14,7 @@ describe Translation do
   let(:phrases) { "{ \"#{element_one_id}\":\"#{phrase_one}\", \"#{element_two_id}\":\"#{phrase_two}\", \"#{element_three_id}\":\"#{phrase_three}\"}" }
   let(:phrase_one_element) { "<content:text i18n-id=\"#{element_one_id}\">#{phrase_one}</content:text>" }
   let(:phrase_two_element) { "<content:text i18n-id=\"#{element_two_id}\">#{phrase_two}</content:text>" }
-  let(:phrase_three_element) { "<content:button type=\"url\" url=\"#{phrase_three}\"><content:text>Label</content:text></content:button>" }
+  let(:phrase_three_element) { "<content:button type=\"url\" url=\"#{phrase_three}\">" }
 
   # rubocop:enable LineLength
 
@@ -46,9 +46,6 @@ describe Translation do
     end
     it 'includes translated phrases' do
       includes_translated_phrases
-    end
-    it 'includes translated attributes' do
-      includes_translated_attributes
     end
   end
 


### PR DESCRIPTION
It searches through the document for all attributes that contain "-i18n-id" in its name, then returns the attributes, search in OneSky by the value, and replace the value with the result, and the name by removing "-i18n-id" from it.