### PR TITLE
widen acceptable event namespaces to include - and _

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -103,7 +103,7 @@
         <xs:list>
             <xs:simpleType>
                 <xs:restriction base="xs:token">
-                    <xs:pattern value="([a-zA-Z0-9]+:)?[a-zA-Z0-9_\-]+" />
+                    <xs:pattern value="([a-zA-Z0-9_\-]+:)?[a-zA-Z0-9_\-]+" />
                 </xs:restriction>
             </xs:simpleType>
         </xs:list>


### PR DESCRIPTION
namespaces for events default to the tool code for the tool containing them. with the addition of "kgp-us" this should be widened to technically support that code as a namespace.