### PR TITLE
GT 381

### DIFF
--- a/app/controllers/translated_pages_controller.rb
+++ b/app/controllers/translated_pages_controller.rb
@@ -23,6 +23,6 @@ class TranslatedPagesController < SecureController
   end
 
   def permitted_params
-    [:value, :page_id, :translation_id]
+    [:value, :resource_id, :language_id]
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -3,6 +3,7 @@
 class Language < ActiveRecord::Base
   has_many :translations
   has_many :custom_pages
+  has_many :translated_pages
 
   validates :name, presence: true
   validates :code, presence: true

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,6 @@
 class Page < AbstractPage
   belongs_to :resource
   has_many :custom_pages
-  has_many :translated_pages
 
   validates :filename, presence: true
   validates :resource, presence: true

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -7,4 +7,5 @@ class Page < AbstractPage
   validates :filename, presence: true
   validates :resource, presence: true
   validates :position, presence: true, uniqueness: { scope: :resource }
+  validates_with UsesOneskyValidator
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -8,6 +8,7 @@ class Resource < ActiveRecord::Base
   has_many :resource_attributes, class_name: 'Attribute'
   has_many :views
   has_many :attachments
+  has_many :translated_pages
 
   validates :name, presence: true
   validates :abbreviation, presence: true, uniqueness: true

--- a/app/models/translated_page.rb
+++ b/app/models/translated_page.rb
@@ -4,7 +4,7 @@ class TranslatedPage < ActiveRecord::Base
   belongs_to :resource
   belongs_to :language
 
-  validates :value, presence: true
+  validates :value, presence: true, xml: { if: :value_changed? }
   validates :resource, presence: true
   validates :language, presence: true
   validate do

--- a/app/models/translated_page.rb
+++ b/app/models/translated_page.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class TranslatedPage < ActiveRecord::Base
-  belongs_to :page
-  belongs_to :translation
+  belongs_to :resource
+  belongs_to :language
 
   validates :value, presence: true
-  validates :page, presence: true
-  validates :translation, presence: true, uniqueness: { scope: :page }
+  validates :resource, presence: true
+  validates :language, presence: true
   validate do
-    errors.add('page', 'Uses OneSky.') if page.resource.uses_onesky?
+    errors.add('resource', 'Uses OneSky.') if resource.uses_onesky?
   end
 end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -12,6 +12,7 @@ class Translation < ActiveRecord::Base
   validates :language, presence: true
   validates :is_published, inclusion: { in: [true, false] }
   validates_with DraftCreationValidator, on: :create
+  validates_with UsesOneskyValidator
 
   before_destroy :prevent_destroy_published, if: :is_published
   before_update :push_published_to_s3

--- a/app/validators/uses_onesky_validator.rb
+++ b/app/validators/uses_onesky_validator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UsesOneskyValidator < ActiveModel::Validator
+  def validate(d)
+    d.errors.add('resource', 'Does not use OneSky.') unless d.resource.uses_onesky?
+  end
+end

--- a/app/validators/xml_validator.rb
+++ b/app/validators/xml_validator.rb
@@ -16,7 +16,7 @@ class XmlValidator < ActiveModel::EachValidator
 
   def xsd_location(record)
     return 'manifest.xsd' if record.is_a?(Resource)
-    return record.resource.resource_type.dtd_file if record.is_a?(Page)
+    return record.resource.resource_type.dtd_file if record.is_a?(Page) || record.is_a?(TranslatedPage)
     return record.page.resource.resource_type.dtd_file if record.is_a?(CustomPage)
 
     raise "Object type: #{record.class} not supported."

--- a/db/migrate/20170807201839_translated_pages_child_of_resource_and_language.rb
+++ b/db/migrate/20170807201839_translated_pages_child_of_resource_and_language.rb
@@ -1,0 +1,12 @@
+class TranslatedPagesChildOfResourceAndLanguage < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :translated_pages, :language, index: true, null: false
+    add_foreign_key :translated_pages, :languages
+
+    add_reference :translated_pages, :resource, index: true, null: false
+    add_foreign_key :translated_pages, :resources
+
+    remove_column :translated_pages, :page_id, :integer
+    remove_column :translated_pages, :translation_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170705203601) do
+ActiveRecord::Schema.define(version: 20170807201839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,12 +114,11 @@ ActiveRecord::Schema.define(version: 20170705203601) do
   end
 
   create_table "translated_pages", force: :cascade do |t|
-    t.string  "value",          null: false
-    t.integer "page_id",        null: false
-    t.integer "translation_id", null: false
-    t.index ["page_id", "translation_id"], name: "index_translated_pages_on_page_id_and_translation_id", unique: true, using: :btree
-    t.index ["page_id"], name: "index_translated_pages_on_page_id", using: :btree
-    t.index ["translation_id"], name: "index_translated_pages_on_translation_id", using: :btree
+    t.string  "value",       null: false
+    t.integer "language_id", null: false
+    t.integer "resource_id", null: false
+    t.index ["language_id"], name: "index_translated_pages_on_language_id", using: :btree
+    t.index ["resource_id"], name: "index_translated_pages_on_resource_id", using: :btree
   end
 
   create_table "translations", force: :cascade do |t|
@@ -150,6 +149,8 @@ ActiveRecord::Schema.define(version: 20170705203601) do
   add_foreign_key "resources", "systems"
   add_foreign_key "translated_attributes", "attributes"
   add_foreign_key "translated_attributes", "translations"
+  add_foreign_key "translated_pages", "languages"
+  add_foreign_key "translated_pages", "resources"
   add_foreign_key "translations", "languages"
   add_foreign_key "translations", "resources"
   add_foreign_key "views", "resources"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,7 +89,7 @@ godtools = System.find_or_create_by!(name: 'GodTools')
 
 kgp = Resource.find_or_create_by!(name: 'Knowing God Personally', resource_type: tract, abbreviation: 'kgp', onesky_project_id: 148_314, system: godtools,
                                   manifest: '<?xml version="1.0"?><manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest" xmlns:content="https://mobile-content-api.cru.org/xmlns/content"><title><content:text i18n-id="89a09d72-114f-4d89-a72c-ca204c796fd9">Knowing God Personally</content:text></title></manifest>')
-satisfied = Resource.find_or_create_by!(name: 'Satisfied?', resource_type: tract, abbreviation: 'sat', system: godtools)
+satisfied = Resource.find_or_create_by!(name: 'Satisfied?', resource_type: tract, abbreviation: 'sat', system: godtools, onesky_project_id: 999_999)
 every_student = Resource.find_or_create_by!(name: 'Questions About God', resource_type: article, abbreviation: 'es', system: godtools)
 
 page_13 = Page.find_or_create_by!(filename: '13_FinalPage.xml', resource: kgp, structure: page_13_structure, position: 1)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,8 +111,8 @@ Translation.find_or_create_by!(resource: satisfied, language: english, version: 
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 1, is_published: true)
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 2, is_published: true)
 
-TranslatedPage.find_or_create_by!(value: 'German article Is There A God?', resource: every_student, language: german)
-TranslatedPage.find_or_create_by!(value: 'German article Beyond Blind Faith', resource: every_student, language: german)
+TranslatedPage.find_or_create_by!(value: is_there_god_structure, resource: every_student, language: german)
+TranslatedPage.find_or_create_by!(value: beyond_blind_faith_structure, resource: every_student, language: german)
 
 AccessCode.find_or_create_by!(code: 123_456)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,10 +95,6 @@ every_student = Resource.find_or_create_by!(name: 'Questions About God', resourc
 page_13 = Page.find_or_create_by!(filename: '13_FinalPage.xml', resource: kgp, structure: page_13_structure, position: 1)
 page_4 = Page.find_or_create_by!(filename: '04_ThirdPoint.xml', resource: kgp, structure: page_4_structure, position: 0)
 
-#TODO remove
-is_there_god = Page.find_or_create_by!(filename: 'Is_There_A_God.xml', resource: every_student, structure: is_there_god_structure, position: 0)
-beyond_blind_faith = Page.find_or_create_by!(filename: 'Beyond_Blind_Faith.xml', resource: every_student, structure: beyond_blind_faith_structure, position: 1)
-
 english = Language.find_or_create_by!(name: 'English', code: 'en')
 german = Language.find_or_create_by!(name: 'German', code: 'de')
 Language.find_or_create_by!(name: 'Slovak', code: 'sk')
@@ -114,10 +110,6 @@ Translation.find_or_create_by!(resource: satisfied, language: english, version: 
 Translation.find_or_create_by!(resource: satisfied, language: english, version: 3)
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 1, is_published: true)
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 2, is_published: true)
-
-#TODO remove
-Translation.find_or_create_by!(resource: every_student, language: english, version: 1, is_published: true)
-german_es = Translation.find_or_create_by!(resource: every_student, language: german, version: 1, is_published: true)
 
 TranslatedPage.find_or_create_by!(value: 'German article Is There A God?', resource: every_student, language: german)
 TranslatedPage.find_or_create_by!(value: 'German article Beyond Blind Faith', resource: every_student, language: german)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,6 +95,7 @@ every_student = Resource.find_or_create_by!(name: 'Questions About God', resourc
 page_13 = Page.find_or_create_by!(filename: '13_FinalPage.xml', resource: kgp, structure: page_13_structure, position: 1)
 page_4 = Page.find_or_create_by!(filename: '04_ThirdPoint.xml', resource: kgp, structure: page_4_structure, position: 0)
 
+#TODO remove
 is_there_god = Page.find_or_create_by!(filename: 'Is_There_A_God.xml', resource: every_student, structure: is_there_god_structure, position: 0)
 beyond_blind_faith = Page.find_or_create_by!(filename: 'Beyond_Blind_Faith.xml', resource: every_student, structure: beyond_blind_faith_structure, position: 1)
 
@@ -114,11 +115,12 @@ Translation.find_or_create_by!(resource: satisfied, language: english, version: 
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 1, is_published: true)
 Translation.find_or_create_by!(resource: satisfied, language: german, version: 2, is_published: true)
 
+#TODO remove
 Translation.find_or_create_by!(resource: every_student, language: english, version: 1, is_published: true)
 german_es = Translation.find_or_create_by!(resource: every_student, language: german, version: 1, is_published: true)
 
-TranslatedPage.find_or_create_by!(value: 'German translation of article Is There A God?', translation: german_es, page: is_there_god)
-TranslatedPage.find_or_create_by!(value: 'German translation of article Beyond Blind Faith', translation: german_es, page: beyond_blind_faith)
+TranslatedPage.find_or_create_by!(value: 'German article Is There A God?', resource: every_student, language: german)
+TranslatedPage.find_or_create_by!(value: 'German article Beyond Blind Faith', resource: every_student, language: german)
 
 AccessCode.find_or_create_by!(code: 123_456)
 

--- a/spec/acceptance/resources_controller_spec.rb
+++ b/spec/acceptance/resources_controller_spec.rb
@@ -34,7 +34,7 @@ resource 'Resources' do
       do_request 'filter[system]': 'GodTools', include: :translations
 
       expect(status).to be(200)
-      expect(JSON.parse(response_body)['included'].count).to be(10)
+      expect(JSON.parse(response_body)['included'].count).to be(8)
     end
   end
 

--- a/spec/acceptance/translated_pages_controller_spec.rb
+++ b/spec/acceptance/translated_pages_controller_spec.rb
@@ -6,7 +6,7 @@ resource 'TranslatedPages' do
   let(:authorization) { AuthToken.create!(access_code: AccessCode.find(1)).token }
   let(:data) do
     { data: { type: :translated_page,
-              attributes: { value: 'This is a translated page.', page_id: 3, translation_id: 1 } } }
+              attributes: { value: 'This is a translated page.', resource_id: 3, language_id: 2 } } }
   end
 
   before do

--- a/spec/acceptance/translated_pages_controller_spec.rb
+++ b/spec/acceptance/translated_pages_controller_spec.rb
@@ -4,10 +4,14 @@ require 'acceptance_helper'
 
 resource 'TranslatedPages' do
   let(:authorization) { AuthToken.create!(access_code: AccessCode.find(1)).token }
-  let(:data) do
-    { data: { type: :translated_page,
-              attributes: { value: 'This is a translated page.', resource_id: 3, language_id: 2 } } }
+  let(:article) do
+    '<?xml version="1.0" encoding="UTF-8" ?>
+<article xmlns="https://mobile-content-api.cru.org/xmlns/article">
+<title>article</title>
+<body>article body</body>
+</article>'
   end
+  let(:data) { { data: { type: :translated_page, attributes: { value: article, resource_id: 3, language_id: 2 } } } }
 
   before do
     header 'Authorization', :authorization

--- a/spec/acceptance/translations_controller_spec.rb
+++ b/spec/acceptance/translations_controller_spec.rb
@@ -11,7 +11,7 @@ resource 'Translations' do
       do_request
 
       expect(status).to be(200)
-      expect(JSON.parse(response_body)['data'].size).to be(8)
+      expect(JSON.parse(response_body)['data'].size).to be(6)
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -32,11 +32,15 @@ describe Page do
   end
 
   it 'cannot duplicate Resource ID and Page position' do
-    result = described_class.create(filename: 'blahblah.xml',
-                                    resource_id: 1,
-                                    structure: structure,
-                                    position: 1)
+    result = described_class.create(filename: 'blahblah.xml', resource_id: 1, structure: structure, position: 1)
 
     expect(result).not_to be_valid
+  end
+
+  it 'cannot be created for resource not using OneSky' do
+    result = described_class.create(filename: 'blahblah.xml', resource_id: 3, structure: structure, position: 1)
+
+    expect(result).not_to be_valid
+    expect(result.errors['resource']).to include('Does not use OneSky.')
   end
 end

--- a/spec/models/translated_page_spec.rb
+++ b/spec/models/translated_page_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 describe TranslatedPage do
-  it 'cannot be created for projects not using OneSky' do
-    result = described_class.create(value: 'what a beautiful day', page_id: 1, translation_id: 3)
+  it 'cannot be created for projects using OneSky' do
+    result = described_class.create(value: 'what a beautiful day', resource_id: 1, language_id: 2)
 
     expect(result).not_to be_valid
-    expect(result.errors['page']).to include('Uses OneSky.')
+    expect(result.errors['resource']).to include('Uses OneSky.')
   end
 end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -172,15 +172,6 @@ describe Translation do
         expect(translation).to have_received(:translated_description=).ordered
         expect(package).to have_received(:push_to_s3).ordered
       end
-
-      it 'does not update from OneSky for projects not using it' do
-        t = described_class.find(7)
-
-        t.update!(id: 7, is_published: true)
-
-        expect(t.translated_name).to be_nil
-        expect(t.translated_description).to be_nil
-      end
     end
   end
 

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -18,7 +18,7 @@ describe Translation do
 
   # rubocop:enable LineLength
 
-  context 'builds a translated page from resource page' do
+  context 'builds a translated page from resource page' do # TODO: rename to avoid confusion with TranslatedPages
     let(:result) do
       translated_page(1)
     end
@@ -72,22 +72,6 @@ describe Translation do
     translation = described_class.find(3)
 
     translation.translated_page(1, false)
-  end
-
-  it 'uses existing translated pages for non-OneSky projects' do
-    translation = described_class.find(10)
-
-    result = translation.translated_page(3, false)
-
-    expect(result).to eq('German translation of article Is There A God?')
-  end
-
-  it 'error raised if translated page not found' do
-    translation = described_class.find(9)
-
-    expect { translation.translated_page(3, false) }.to(
-      raise_error(Error::TextNotFoundError, 'Translated page not found for this language.')
-    )
   end
 
   it 'is invalid if draft exists' do

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -18,7 +18,7 @@ describe Translation do
 
   # rubocop:enable LineLength
 
-  context 'builds a translated page from resource page' do # TODO: rename to avoid confusion with TranslatedPages
+  context 'builds a translated page from base page and OneSky phrases' do
     let(:result) do
       translated_page(1)
     end
@@ -36,7 +36,7 @@ describe Translation do
     end
   end
 
-  context 'builds a translated page from custom page' do
+  context 'builds a translated page from custom page and OneSky phrases' do
     let(:result) do
       translated_page(3)
     end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -174,9 +174,9 @@ describe Translation do
       end
 
       it 'does not update from OneSky for projects not using it' do
-        t = described_class.find(9)
+        t = described_class.find(7)
 
-        t.update!(id: 9, is_published: true)
+        t.update!(id: 7, is_published: true)
 
         expect(t.translated_name).to be_nil
         expect(t.translated_description).to be_nil

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -116,7 +116,7 @@ describe Package do
 
     context 'resource does not have a manifest file' do
       let(:translation) do
-        t = Translation.find(10)
+        t = Translation.find(8)
         allow(t).to(receive(:translated_page).and_return(translated_page_one, translated_page_two))
         t
       end


### PR DESCRIPTION
This PR addresses an issue with EveryStudent content.  With our tracts such as GodTools/Satisfied, they are built in a base language (English) and all the translated versions are based on that.  We could not use the same methods for EveryStudent content because there is no base language; we simply want to store as many articles as we have for each language.  Therefore TranslatedPages will not be related to Pages/Translations as the latter classes are only for content that is generated dynamically.

@frett fyi