### PR TITLE
Save follow ups in the database

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
     params.require(:data).require(:attributes)
   end
 
+  def permit_params(*params)
+    data_attrs.permit(params)
+  end
+
   def authorize!
     authorization = AuthToken.find_by(token: request.headers['Authorization'])
     return unless authorization.nil? || expired(authorization)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -8,12 +8,12 @@ class AttachmentsController < ApplicationController
   end
 
   def create
-    a = Attachment.create!(params.permit(permitted_params))
+    a = Attachment.create!(permitted_params)
     head :no_content, location: "attachments/#{a.id}"
   end
 
   def update
-    load_attachment.update!(params.permit(permitted_params))
+    load_attachment.update!(permitted_params)
     head :no_content
   end
 
@@ -29,6 +29,6 @@ class AttachmentsController < ApplicationController
   end
 
   def permitted_params
-    [:resource_id, :file, :is_zipped]
+    params.permit([:resource_id, :file, :is_zipped])
   end
 end

--- a/app/controllers/attributes_controller.rb
+++ b/app/controllers/attributes_controller.rb
@@ -35,6 +35,6 @@ class AttributesController < SecureController
   end
 
   def permitted_params
-    data_attrs.permit([:key, :value, :resource_id])
+    permit_params(:key, :value, :resource_id)
   end
 end

--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -16,14 +16,14 @@ class CustomPagesController < SecureController
   private
 
   def create_custom_page
-    created = CustomPage.create!(data_attrs.permit(:language_id, :page_id, :structure))
+    created = CustomPage.create!(permit_params(:language_id, :page_id, :structure))
     response.headers['Location'] = "custom_pages/#{created.id}"
     render json: created, status: :created
   end
 
   def update_custom_page
     existing = CustomPage.find_by(language_id: data_attrs[:language_id], page_id: data_attrs[:page_id])
-    existing.update!(data_attrs.permit(:structure))
+    existing.update!(permit_params(:structure))
     render json: existing, status: :ok
   end
 end

--- a/app/controllers/follow_ups_controller.rb
+++ b/app/controllers/follow_ups_controller.rb
@@ -10,6 +10,6 @@ class FollowUpsController < ApplicationController
   private
 
   def permitted_params
-    data_attrs.permit([:email, :language_id, :destination_id, :name])
+    permit_params(:email, :language_id, :destination_id, :name)
   end
 end

--- a/app/controllers/follow_ups_controller.rb
+++ b/app/controllers/follow_ups_controller.rb
@@ -2,7 +2,7 @@
 
 class FollowUpsController < ApplicationController
   def create
-    f = FollowUp.create!(data_attrs.permit(permitted_params))
+    f = FollowUp.create!(permitted_params)
     f.send_to_api
     head :no_content
   end
@@ -10,6 +10,6 @@ class FollowUpsController < ApplicationController
   private
 
   def permitted_params
-    [:email, :language_id, :destination_id, :name]
+    data_attrs.permit([:email, :language_id, :destination_id, :name])
   end
 end

--- a/app/controllers/follow_ups_controller.rb
+++ b/app/controllers/follow_ups_controller.rb
@@ -2,8 +2,14 @@
 
 class FollowUpsController < ApplicationController
   def create
-    f = FollowUp.new(data_attrs[:email], data_attrs[:language_id], data_attrs[:destination_id], data_attrs[:name])
+    f = FollowUp.create!(data_attrs.permit(permitted_params))
     f.send_to_api
     head :no_content
+  end
+
+  private
+
+  def permitted_params
+    [:email, :language_id, :destination_id, :name]
   end
 end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -12,7 +12,7 @@ class LanguagesController < ApplicationController
   end
 
   def create
-    language = Language.create!(data_attrs.permit(:name, :code))
+    language = Language.create!(permit_params(:name, :code))
     response.headers['Location'] = "languages/#{language.id}"
     render json: language, status: :created
   rescue ActiveRecord::RecordNotUnique

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -14,12 +14,12 @@ class ResourcesController < ApplicationController
   end
 
   def create
-    r = Resource.create!(data_attrs.permit(permitted_params))
+    r = Resource.create!(permitted_params)
     render json: r, status: :created
   end
 
   def update
-    r = load_resource.update!(data_attrs.permit(permitted_params))
+    r = load_resource.update!(permitted_params)
     render json: r, status: :ok
   end
 
@@ -44,6 +44,7 @@ class ResourcesController < ApplicationController
   end
 
   def permitted_params
-    [:name, :abbreviation, :manifest, :onesky_project_id, :system_id, :description, :resource_type_id]
+    data_attrs
+      .permit([:name, :abbreviation, :manifest, :onesky_project_id, :system_id, :description, :resource_type_id])
   end
 end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -44,7 +44,6 @@ class ResourcesController < ApplicationController
   end
 
   def permitted_params
-    data_attrs
-      .permit([:name, :abbreviation, :manifest, :onesky_project_id, :system_id, :description, :resource_type_id])
+    permit_params(:name, :abbreviation, :manifest, :onesky_project_id, :system_id, :description, :resource_type_id)
   end
 end

--- a/app/controllers/translated_attributes_controller.rb
+++ b/app/controllers/translated_attributes_controller.rb
@@ -16,12 +16,12 @@ class TranslatedAttributesController < SecureController
   private
 
   def create_translated_attr
-    a = TranslatedAttribute.create!(data_attrs.permit(permitted_params))
+    a = TranslatedAttribute.create!(permitted_params)
     head :no_content, location: "translated_attributes/#{a.id}"
   end
 
   def update_translated_attr
-    load_translated_attr.update!(data_attrs.permit(permitted_params))
+    load_translated_attr.update!(permitted_params)
     head :no_content
   end
 
@@ -35,6 +35,6 @@ class TranslatedAttributesController < SecureController
   end
 
   def permitted_params
-    [:value, :attribute_id, :translation_id]
+    data_attrs.permit([:value, :attribute_id, :translation_id])
   end
 end

--- a/app/controllers/translated_attributes_controller.rb
+++ b/app/controllers/translated_attributes_controller.rb
@@ -35,6 +35,6 @@ class TranslatedAttributesController < SecureController
   end
 
   def permitted_params
-    data_attrs.permit([:value, :attribute_id, :translation_id])
+    permit_params(:value, :attribute_id, :translation_id)
   end
 end

--- a/app/controllers/translated_pages_controller.rb
+++ b/app/controllers/translated_pages_controller.rb
@@ -2,12 +2,12 @@
 
 class TranslatedPagesController < SecureController
   def create
-    t = TranslatedPage.create!(data_attrs.permit(permitted_params))
+    t = TranslatedPage.create!(permitted_params)
     render json: t, location: "translated_pages/#{t.id}", status: :created
   end
 
   def update
-    t = load_translated_page.update!(data_attrs.permit(permitted_params))
+    t = load_translated_page.update!(permitted_params)
     render json: t, status: :created
   end
 
@@ -23,6 +23,6 @@ class TranslatedPagesController < SecureController
   end
 
   def permitted_params
-    [:value, :resource_id, :language_id]
+    data_attrs.permit([:value, :resource_id, :language_id])
   end
 end

--- a/app/controllers/translated_pages_controller.rb
+++ b/app/controllers/translated_pages_controller.rb
@@ -23,6 +23,6 @@ class TranslatedPagesController < SecureController
   end
 
   def permitted_params
-    data_attrs.permit([:value, :resource_id, :language_id])
+    permit_params(:value, :resource_id, :language_id)
   end
 end

--- a/app/controllers/views_controller.rb
+++ b/app/controllers/views_controller.rb
@@ -2,7 +2,7 @@
 
 class ViewsController < ApplicationController
   def create
-    View.create!(data_attrs.permit(:quantity, :resource_id))
+    View.create!(permit_params(:quantity, :resource_id))
     head :no_content
   end
 end

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -2,9 +2,7 @@
 
 require 'rest-client'
 
-class FollowUp
-  include ActiveModel::Validations
-
+class FollowUp < ActiveRecord::Base
   attr_accessor :email, :name, :language, :destination
 
   validates :email, presence: true, email_format: { message: 'Invalid email address' }

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -12,10 +12,8 @@ class FollowUp < ActiveRecord::Base
 
   def send_to_api
     save! if changed?
-
     Rails.logger.info "Sending follow up with id: #{id}."
-    code = RestClient.post(destination.url, body, headers).code
-    raise Error::BadRequestError, "Received response code: #{code} from destination: #{destination.id}" if code != 201
+    perform_request
   end
 
   private
@@ -36,5 +34,10 @@ class FollowUp < ActiveRecord::Base
     { 'Access-Id': destination.access_key_id,
       'Access-Secret': destination.access_key_secret,
       'Content-Type': 'application/x-www-form-urlencoded' }
+  end
+
+  def perform_request
+    code = RestClient.post(destination.url, body, headers).code
+    raise Error::BadRequestError, "Received response code: #{code} from destination: #{destination.id}" if code != 201
   end
 end

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -11,7 +11,7 @@ class FollowUp < ActiveRecord::Base
   validates :destination, presence: true
 
   def send_to_api
-    validate_fields
+    save!
 
     Rails.logger.info "Sending follow up with id: #{id}."
     code = RestClient.post(destination.url, body, headers).code
@@ -19,10 +19,6 @@ class FollowUp < ActiveRecord::Base
   end
 
   private
-
-  def validate_fields
-    raise Error::BadRequestError, errors.full_messages.join(', ') unless valid?
-  end
 
   def body
     "subscriber[route_id]=#{destination.route_id}&subscriber[language_code]=#{language.code}"\

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -20,6 +20,8 @@ class FollowUp
 
   def send_to_api
     validate_fields
+
+    Rails.logger.info 'Sending request to destination'
     code = RestClient.post(destination.url, body, headers).code
     raise Error::BadRequestError, "Received response code: #{code} from destination: #{destination.id}" if code != 201
   end

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -11,7 +11,7 @@ class FollowUp < ActiveRecord::Base
   validates :destination, presence: true
 
   def send_to_api
-    save!
+    save! if changed?
 
     Rails.logger.info "Sending follow up with id: #{id}."
     code = RestClient.post(destination.url, body, headers).code

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -3,18 +3,12 @@
 require 'rest-client'
 
 class FollowUp < ActiveRecord::Base
-  attr_accessor :email, :name, :language, :destination
+  belongs_to :language
+  belongs_to :destination
 
   validates :email, presence: true, email_format: { message: 'Invalid email address' }
   validates :language, presence: true
   validates :destination, presence: true
-
-  def initialize(email, language_id, destination_id, name = nil)
-    self.email = email
-    self.language = Language.find(language_id)
-    self.destination = Destination.find(destination_id)
-    self.name = name
-  end
 
   def send_to_api
     validate_fields

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -19,7 +19,7 @@ class FollowUp < ActiveRecord::Base
   def send_to_api
     validate_fields
 
-    Rails.logger.info 'Sending request to destination'
+    Rails.logger.info "Sending follow up with id: #{id}."
     code = RestClient.post(destination.url, body, headers).code
     raise Error::BadRequestError, "Received response code: #{code} from destination: #{destination.id}" if code != 201
   end

--- a/db/migrate/20170919235321_store_follow_ups.rb
+++ b/db/migrate/20170919235321_store_follow_ups.rb
@@ -1,0 +1,13 @@
+class StoreFollowUps < ActiveRecord::Migration[5.0]
+  def change
+    create_table :follow_ups do |t|
+      t.string :email, null: false
+      t.string :name, null: true
+      t.references :language, null: false
+      t.references :destination, null: false
+    end
+
+    add_foreign_key :follow_ups, :languages
+    add_foreign_key :follow_ups, :destinations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901192625) do
+ActiveRecord::Schema.define(version: 20170919235321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,15 @@ ActiveRecord::Schema.define(version: 20170901192625) do
     t.string "route_id"
     t.string "access_key_id"
     t.string "access_key_secret"
+  end
+
+  create_table "follow_ups", force: :cascade do |t|
+    t.string  "email",          null: false
+    t.string  "name"
+    t.integer "language_id",    null: false
+    t.integer "destination_id", null: false
+    t.index ["destination_id"], name: "index_follow_ups_on_destination_id", using: :btree
+    t.index ["language_id"], name: "index_follow_ups_on_language_id", using: :btree
   end
 
   create_table "languages", force: :cascade do |t|
@@ -145,6 +154,8 @@ ActiveRecord::Schema.define(version: 20170901192625) do
   add_foreign_key "auth_tokens", "access_codes"
   add_foreign_key "custom_pages", "languages"
   add_foreign_key "custom_pages", "pages"
+  add_foreign_key "follow_ups", "destinations"
+  add_foreign_key "follow_ups", "languages"
   add_foreign_key "pages", "resources"
   add_foreign_key "resources", "resource_types"
   add_foreign_key "resources", "systems"

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -14,7 +14,8 @@ describe FollowUp do
   let(:full_name) { "#{first_name} #{last_name}" }
 
   it 'validates email address' do
-    result = described_class.create(email: 'myemail', language_id: language.id, destination_id: destination.id, name: full_name)
+    result = described_class
+             .create(email: 'myemail', language_id: language.id, destination_id: destination.id, name: full_name)
 
     expect(result).not_to be_valid
     expect(result.errors[:email]).to include('Invalid email address')
@@ -22,7 +23,7 @@ describe FollowUp do
 
   it 'returns remote response code if request failed' do
     code = 404
-    follow_up = described_class.create(email: email, language_id: language.id, destination_id: destination.id, name: full_name)
+    follow_up = described_class.create(valid_attrs)
     mock_rest_client(code)
 
     expect { follow_up.send_to_api }
@@ -31,7 +32,7 @@ describe FollowUp do
 
   it 'saves record before sending to destination' do
     mock_rest_client(201)
-    follow_up = described_class.new(email: email, language_id: language.id, destination_id: destination.id, name: full_name)
+    follow_up = described_class.new(valid_attrs)
     allow(follow_up).to receive(:save!)
 
     follow_up.send_to_api
@@ -40,7 +41,7 @@ describe FollowUp do
   end
 
   context 'sends correct values to api' do
-    let(:follow_up) { described_class.create(email: email, language_id: language.id, destination_id: destination.id, name: full_name) }
+    let(:follow_up) { described_class.create(valid_attrs) }
 
     before do
       mock_rest_client(201)
@@ -79,6 +80,10 @@ describe FollowUp do
   end
 
   private
+
+  def valid_attrs
+    { email: email, language_id: language.id, destination_id: destination.id, name: full_name }
+  end
 
   def mock_rest_client(code)
     allow(RestClient).to(

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -14,7 +14,7 @@ describe FollowUp do
   let(:full_name) { "#{first_name} #{last_name}" }
 
   it 'validates email address' do
-    result = described_class.new('myemail', language.id, destination.id, full_name)
+    result = described_class.create(email: 'myemail', language_id: language.id, destination_id: destination.id, name: full_name)
 
     expect(result).not_to be_valid
     expect(result.errors[:email]).to include('Invalid email address')
@@ -22,7 +22,7 @@ describe FollowUp do
 
   it 'returns remote response code if request failed' do
     code = 404
-    follow_up = described_class.new(email, language.id, destination.id, full_name)
+    follow_up = described_class.create(email: email, language_id: language.id, destination_id: destination.id, name: full_name)
     mock_rest_client(code)
 
     expect { follow_up.send_to_api }
@@ -30,13 +30,13 @@ describe FollowUp do
   end
 
   it 'does not send if record is invalid' do
-    follow_up = described_class.new(nil, language.id, destination.id, full_name)
+    follow_up = described_class.create(email: nil, language_id: language.id, destination_id: destination.id, name: full_name)
 
     expect { follow_up.send_to_api }.to raise_error("Email can't be blank, Email Invalid email address")
   end
 
   context 'sends correct values to api' do
-    let(:follow_up) { described_class.new(email, language.id, destination.id, full_name) }
+    let(:follow_up) { described_class.create(email: email, language_id: language.id, destination_id: destination.id, name: full_name) }
 
     before do
       mock_rest_client(201)

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -29,10 +29,14 @@ describe FollowUp do
       .to raise_error("Received response code: #{code} from destination: #{destination.id}")
   end
 
-  it 'does not send if record is invalid' do
-    follow_up = described_class.create(email: nil, language_id: language.id, destination_id: destination.id, name: full_name)
+  it 'saves record before sending to destination' do
+    mock_rest_client(201)
+    follow_up = described_class.new(email: email, language_id: language.id, destination_id: destination.id, name: full_name)
+    allow(follow_up).to receive(:save!)
 
-    expect { follow_up.send_to_api }.to raise_error("Email can't be blank, Email Invalid email address")
+    follow_up.send_to_api
+
+    expect(follow_up).to have_received(:save!)
   end
 
   context 'sends correct values to api' do

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -30,7 +30,7 @@ describe FollowUp do
       .to raise_error("Received response code: #{code} from destination: #{destination.id}")
   end
 
-  it 'saves record before sending to destination' do
+  it 'ensures record is saved before sending to destination' do
     mock_rest_client(201)
     follow_up = described_class.new(valid_attrs)
     allow(follow_up).to receive(:save!)


### PR DESCRIPTION
I decided this would be a good idea after this: https://rollbar.com/Cru/mobile-content-api/items/73/.  The error appears to be a one-off thing, but since the follow-ups aren't stored we have no way of knowing what the actual data was.

Also, in the event of an error, it would be helpful to resend the data to make sure the user gets subscribed as desired