### PR TITLE
add support for defining text-style="bold"

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -96,6 +96,8 @@
     <xs:simpleType name="textStyle">
         <xs:restriction base="xs:token">
             <xs:enumeration value="bold" />
+            <xs:enumeration value="italic" />
+            <xs:enumeration value="underline" />
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="textStyles">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -93,6 +93,15 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="textStyle">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="bold" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="textStyles">
+        <xs:list itemType="content:textStyle" />
+    </xs:simpleType>
+
     <xs:simpleType name="uri">
         <xs:restriction base="xs:anyURI">
             <xs:pattern value="https?://.*" />
@@ -158,6 +167,11 @@
                 </xs:attribute>
                 <xs:attribute name="text-color" type="content:colorValue" use="optional" />
                 <xs:attribute name="text-scale" type="xs:float" use="optional" />
+                <xs:attribute name="text-style" type="content:textStyles" default="">
+                    <xs:annotation>
+                        <xs:documentation>Defines any typeface styles to apply to this text content.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
`text-style` is a token list, so multiple space-separate styles could be defined. currently we only define the `bold` style.

example text node:
```xml
<content:text text-style="bold">Bold Text</content:text>
<content:text text-style="italic underline">Underlined Italic text</content:text>
```