### PR TITLE
Add button-color attribute to callToAction element

### DIFF
--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -219,6 +219,11 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="button-color" type="content:colorValue" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>This attribute defines the rgba color of the call to action button.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -219,7 +219,8 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <!-- control-color: DEFAULT "GodTools blue" rgba(59,164,219,1) . -->
+                <!-- control-color: iOS DEFAULT is "GodTools blue" rgba(59,164,219,1) , Android DEFAULT is the primary-color attribute set at the
+                nearest ancestor either page, or manifest. -->
                 <xs:attribute name="control-color" type="content:colorValue" use="optional">
                     <xs:annotation>
                         <xs:documentation>This attribute defines the rgba color of the call to action control (button).</xs:documentation>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -219,11 +219,10 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <!-- control-color: iOS DEFAULT is "GodTools blue" rgba(59,164,219,1) , Android DEFAULT is the primary-color attribute set at the
-                nearest ancestor either page, or manifest. -->
                 <xs:attribute name="control-color" type="content:colorValue" use="optional">
                     <xs:annotation>
-                        <xs:documentation>This attribute defines the rgba color of the call to action control (button).</xs:documentation>
+                        <xs:documentation>This attribute defines the rgba color of the call to action control (button).
+                            DEFAULT is the primary-color attribute set at the nearest ancestor either page, or manifest.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -219,9 +219,10 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="button-color" type="content:colorValue" use="optional">
+                <!-- control-color: DEFAULT "GodTools blue" rgba(59,164,219,1) . -->
+                <xs:attribute name="control-color" type="content:colorValue" use="optional">
                     <xs:annotation>
-                        <xs:documentation>This attribute defines the rgba color of the call to action button.</xs:documentation>
+                        <xs:documentation>This attribute defines the rgba color of the call to action control (button).</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>


### PR DESCRIPTION
Is optional, and must follow rbga(#,#,#,#) format. Colors only the button, not any descendent text elements