### PR TITLE
Update nokogiri to fix vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'aws-sdk'
 gem 'aws-sdk-rails'
 gem 'codecov', require: false
 gem 'ddtrace'
-gem 'nokogiri', '>= 1.8.1'
+gem 'nokogiri', '>= 1.8.2'
 gem 'oj', '~> 2.12.14'
 gem 'paperclip'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     nenv (0.3.0)
     netrc (0.11.0)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -333,7 +333,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
-  nokogiri (>= 1.8.1)
+  nokogiri (>= 1.8.2)
   oj (~> 2.12.14)
   paperclip
   pg


### PR DESCRIPTION
This repo is public so security vulnerabilities should be fixed ASAP.