### PR TITLE
Gt 449 right to left attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'aws-sdk'
 gem 'aws-sdk-rails'
 gem 'codecov', require: false
 gem 'ddtrace'
-gem 'nokogiri', '>= 1.8.1'
+gem 'nokogiri', '>= 1.8.2'
 gem 'oj', '~> 2.12.14'
 gem 'paperclip'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     nenv (0.3.0)
     netrc (0.11.0)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -333,7 +333,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
-  nokogiri (>= 1.8.1)
+  nokogiri (>= 1.8.2)
   oj (~> 2.12.14)
   paperclip
   pg

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -12,7 +12,7 @@ class LanguagesController < ApplicationController
   end
 
   def create
-    language = Language.create!(permit_params(:name, :code))
+    language = Language.create!(permit_params(:name, :code, :direction))
     response.headers['Location'] = "languages/#{language.id}"
     render json: language, status: :created
   rescue ActiveRecord::RecordNotUnique

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -7,4 +7,5 @@ class Language < ActiveRecord::Base
 
   validates :name, presence: true
   validates :code, presence: true
+  validates_with LanguageValidator, on: :create
 end

--- a/app/serializers/language_serializer.rb
+++ b/app/serializers/language_serializer.rb
@@ -2,7 +2,7 @@
 
 class LanguageSerializer < ActiveModel::Serializer
   type 'language'
-  attributes :id, :code, :name
+  attributes :id, :code, :name, :direction
 
   has_many :translations
   has_many :custom_pages

--- a/app/validators/language_validator.rb
+++ b/app/validators/language_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class LanguageValidator < ActiveModel::Validator
+  def validate(l)
+    if ["ltr", "rtl"].include?(l.direction)
+      return
+    end
+    l.errors.add(l.direction, "Invalid direction #{l.direction}. Valid values for direction are 'ltr' and 'rtl'")
+  end
+end

--- a/app/validators/language_validator.rb
+++ b/app/validators/language_validator.rb
@@ -2,9 +2,7 @@
 
 class LanguageValidator < ActiveModel::Validator
   def validate(l)
-    if ["ltr", "rtl"].include?(l.direction)
-      return
-    end
+    return if %w[ltr rtl].include?(l.direction)
     l.errors.add(l.direction, "Invalid direction #{l.direction}. Valid values for direction are 'ltr' and 'rtl'")
   end
 end

--- a/db/migrate/20180212221933_add_direction_to_languages.rb
+++ b/db/migrate/20180212221933_add_direction_to_languages.rb
@@ -1,0 +1,5 @@
+class AddDirectionToLanguages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :languages, :direction, :string, default => "ltr"
+  end
+end

--- a/db/migrate/20180212221933_add_direction_to_languages.rb
+++ b/db/migrate/20180212221933_add_direction_to_languages.rb
@@ -1,5 +1,5 @@
 class AddDirectionToLanguages < ActiveRecord::Migration[5.0]
   def change
-    add_column :languages, :direction, :string, default => "ltr"
+    add_column :languages, :direction, :string, default: 'ltr'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170919235321) do
+ActiveRecord::Schema.define(version: 20180212221933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,8 +75,9 @@ ActiveRecord::Schema.define(version: 20170919235321) do
   end
 
   create_table "languages", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "code", null: false
+    t.string "name",                      null: false
+    t.string "code",                      null: false
+    t.string "direction", default: "ltr"
     t.index ["code"], name: "index_languages_on_code", unique: true, using: :btree
   end
 

--- a/spec/acceptance/languages_controller_spec.rb
+++ b/spec/acceptance/languages_controller_spec.rb
@@ -73,6 +73,13 @@ resource 'Languages' do
 
       expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq("rtl")
     end
+
+    it 'fails on invalid direction value', document: false do
+      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'bogus' } }
+
+      expect(status).to be(400)
+      expect(JSON.parse(response_body)['errors'][0]['detail']).to eq("Validation failed: Bogus Invalid direction bogus. Valid values for direction are 'ltr' and 'rtl'")
+    end
   end
 
   delete 'languages/:id' do

--- a/spec/acceptance/languages_controller_spec.rb
+++ b/spec/acceptance/languages_controller_spec.rb
@@ -61,6 +61,18 @@ resource 'Languages' do
       expect(status).to be(400)
       expect(JSON.parse(response_body)['errors'][0]['detail']).to eq("Code #{code} already exists.")
     end
+
+    it 'defaults direction to ltr', document: false do
+      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev' } }
+
+      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq("ltr")
+    end
+
+    it 'honors direction when set to rtl', document: false do
+      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'rtl' } }
+
+      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq("rtl")
+    end
   end
 
   delete 'languages/:id' do

--- a/spec/acceptance/languages_controller_spec.rb
+++ b/spec/acceptance/languages_controller_spec.rb
@@ -65,20 +65,21 @@ resource 'Languages' do
     it 'defaults direction to ltr', document: false do
       do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev' } }
 
-      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq("ltr")
+      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq('ltr')
     end
 
     it 'honors direction when set to rtl', document: false do
       do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'rtl' } }
 
-      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq("rtl")
+      expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq('rtl')
     end
 
     it 'fails on invalid direction value', document: false do
       do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'bogus' } }
 
+      error = "Validation failed: Bogus Invalid direction bogus. Valid values for direction are 'ltr' and 'rtl'"
       expect(status).to be(400)
-      expect(JSON.parse(response_body)['errors'][0]['detail']).to eq("Validation failed: Bogus Invalid direction bogus. Valid values for direction are 'ltr' and 'rtl'")
+      expect(JSON.parse(response_body)['errors'][0]['detail']).to eq(error)
     end
   end
 


### PR DESCRIPTION
Adds "direction" attribute to language. This attribute will help clients know which way text ought to be rendered for a given languages. Defaults to "ltr" unless otherwise specified.

endpoint validates values to be either: "ltr" and "rtl"