### PR TITLE
RFC: Define Analytics events in tract XML

### DIFF
--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -47,13 +47,50 @@
                 <xs:element name="attribute" maxOccurs="unbounded" minOccurs="0">
                     <xs:complexType>
                         <xs:attribute name="key" use="required" />
-                        <xs:attribute name="value" use="optional" />
+                        <xs:attribute name="value" use="optional" default="" />
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
             <xs:attribute name="system" type="analytics:systemType" />
             <xs:attribute name="action" type="xs:string" />
             <xs:attribute name="delay" default="0" type="xs:int" />
+            <xs:attribute name="trigger" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        This attribute defines the mechanism that triggers this analytics event. Elements may only
+                        support specific trigger modes and the default value is dependent on the element the event is
+                        in.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                        <xs:enumeration value="selected">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    This event is triggered when the element containing it is triggered. For example,
+                                    a user selects a tab in the content:tabs element.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="visible">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    This event is triggered when the element containing the event becomes visible. For
+                                    example, a card within a tract becomes active and is visible to the user.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="hidden">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    This event is triggered when the element containing it is no longer visible. For
+                                    example, a user navigates away from an active card.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    targetNamespace="https://mobile-content-api.cru.org/xmlns/analytics">
+
+    <xs:simpleType name="systemType">
+        <xs:annotation>
+            <xs:documentation>The analytic systems being targeted by a specific analytics event</xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="adobe">
+                        <xs:annotation>
+                            <xs:documentation>Adobe Analytics</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="google">
+                        <xs:annotation>
+                            <xs:documentation>Google Analytics</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="snowplow">
+                        <xs:annotation>
+                            <xs:documentation>Snowplow Analytics</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:element name="events">
+        <xs:annotation>
+            <xs:documentation>A group of analytics events</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="analytics:event" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="event">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="attribute" maxOccurs="unbounded" minOccurs="0">
+                    <xs:complexType>
+                        <xs:attribute name="key" use="required" />
+                        <xs:attribute name="value" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+            <xs:attribute name="system" type="analytics:systemType" />
+            <xs:attribute name="action" type="xs:string" />
+            <xs:attribute name="delay" default="0" type="xs:int" />
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -47,13 +47,29 @@
                 <xs:element name="attribute" maxOccurs="unbounded" minOccurs="0">
                     <xs:complexType>
                         <xs:attribute name="key" use="required" />
-                        <xs:attribute name="value" use="optional" default="" />
+                        <xs:attribute name="value" default="" />
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
-            <xs:attribute name="system" type="analytics:systemType" />
-            <xs:attribute name="action" type="xs:string" />
-            <xs:attribute name="delay" default="0" type="xs:int" />
+            <xs:attribute name="system" type="analytics:systemType">
+                <xs:annotation>
+                    <xs:documentation>Space separated list of analytics systems this event is for.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="action" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Analytics action being triggered.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="delay" default="0" type="xs:int">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the number of seconds to wait before triggering this analytics event. This event can be
+                        canceled if the trigger mode is no longer applicable (e.g. trigger=visible & element is no
+                        longer visible).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="trigger" use="optional">
                 <xs:annotation>
                     <xs:documentation>

--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -65,7 +65,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Defines the number of seconds to wait before triggering this analytics event. This event can be
-                        canceled if the trigger mode is no longer applicable (e.g. trigger=visible & element is no
+                        canceled if the trigger mode is no longer applicable (e.g. trigger=visible and element is no
                         longer visible).
                     </xs:documentation>
                 </xs:annotation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -232,6 +232,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element ref="analytics:events">
+                <xs:annotation>
+                    <xs:documentation>
+                        Define any analytics events that are triggered by this button. The default trigger mode for
+                        analytics events on buttons is "selected".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
         <xs:attribute name="type" use="required">
             <xs:annotation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -284,17 +284,27 @@
         </xs:attribute>
     </xs:complexType>
 
-    <!--
-        Link
-            text-color: DEFAULT( inherit primary-color )
-    -->
+    <!-- Link -->
     <xs:complexType name="link">
-        <xs:complexContent>
-            <xs:extension base="content:textChild">
-                <!-- events: events to fire when link is pressed. -->
-                <xs:attribute name="events" type="content:eventIdsType" use="required" />
-            </xs:extension>
-        </xs:complexContent>
+        <xs:sequence>
+            <xs:element ref="content:text">
+                <xs:annotation>
+                    <xs:documentation>This element is the text content of this link. The text-color attribute defaults
+                        to the primary-color of the closest ancestor container.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Define any analytics events that are triggered by this link. The default trigger mode
+                        for analytics events on links is "selected".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <!-- events: events to fire when link is pressed. -->
+        <xs:attribute name="events" type="content:eventIdsType" use="required" />
     </xs:complexType>
 
     <!--

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    attributeFormDefault="unqualified" elementFormDefault="qualified"
-    targetNamespace="https://mobile-content-api.cru.org/xmlns/content">
+<xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/content">
+
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
 
     <!-- Value definitions -->
     <xs:simpleType name="colorValue">
@@ -143,6 +145,14 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="label" type="content:textChild" />
+                        <xs:element ref="analytics:events" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Analytics Events to trigger for a tab. The default trigger mode for tab analytics
+                                    events is "selected".
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
                             <xs:group ref="content:elements" />
                         </xs:choice>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -223,7 +223,7 @@
         </content:button>
     -->
     <xs:complexType name="button">
-        <xs:all>
+        <xs:sequence>
             <xs:element ref="content:text">
                 <xs:annotation>
                     <xs:documentation>This element is the text content of this button. The text-color attribute defaults
@@ -240,7 +240,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-        </xs:all>
+        </xs:sequence>
         <xs:attribute name="type" use="required">
             <xs:annotation>
                 <xs:documentation>This attribute determines what type of button this is.</xs:documentation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -145,7 +145,7 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="label" type="content:textChild" />
-                        <xs:element ref="analytics:events" minOccurs="0">
+                        <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>
                                     Analytics Events to trigger for a tab. The default trigger mode for tab analytics
@@ -232,7 +232,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element ref="analytics:events">
+            <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Define any analytics events that are triggered by this button. The default trigger mode for

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    targetNamespace="https://mobile-content-api.cru.org/xmlns/tract">
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/tract">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
@@ -158,7 +157,7 @@
                     text-color: DEFAULT( primary-text-color )
             -->
             <xs:element name="label" type="content:textChild" />
-            <xs:element ref="analytics:events" minOccurs="0">
+            <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Analytics events to trigger for cards. The default trigger mode for analytics events on cards is

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    attributeFormDefault="unqualified" elementFormDefault="qualified"
+<xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
     targetNamespace="https://mobile-content-api.cru.org/xmlns/tract">
 
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
 
     <!-- element nodes -->
@@ -156,6 +158,7 @@
                     text-color: DEFAULT( primary-text-color )
             -->
             <xs:element name="label" type="content:textChild" />
+            <xs:element ref="analytics:events" minOccurs="0" />
             <!--
                 Content section - OPTIONAL
                     text-scale: DEFAULT( 1.0 )

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -158,7 +158,14 @@
                     text-color: DEFAULT( primary-text-color )
             -->
             <xs:element name="label" type="content:textChild" />
-            <xs:element ref="analytics:events" minOccurs="0" />
+            <xs:element ref="analytics:events" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Analytics events to trigger for cards. The default trigger mode for analytics events on cards is
+                        "visible".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <!--
                 Content section - OPTIONAL
                     text-scale: DEFAULT( 1.0 )


### PR DESCRIPTION
This defines an `<analytics:event>` xml node for use within tract XML to define when & what analytics events to trigger for specific content interactions.

a sample of what this xml would be:
```xml
<card>
  <label>
    <content:text>Here is a suggested prayer</content:text>
  </label>
  <analytics:events>
    <analytics:event action="KGP Gospel Presented" delay="5" system="adobe" trigger="visible">
      <analytics:attribute key="cru.presentingthegospel" value="" />
    </analytics:event>
  </analytics:events>
</card>

<button>
  <content:text>Button</content:text>
  <analytics:events>
    <analytics:event action="FourLaws Email Sign Up" system="adobe" trigger="selected">
      <analytics:attribute key="cru.emailsignup" value="true" />
      <analytics:attribute key="cru.emaillist" value="5" />
    </analytics:event>
  </analytics:events>
</button>

<link>
  <content:text>Link</content:text>
  <analytics:events>
    <analytics:event action="FourLaws Email Sign Up" system="adobe" trigger="selected">
      <analytics:attribute key="cru.emailsignup" value="true" />
      <analytics:attribute key="cru.emaillist" value="5" />
    </analytics:event>
  </analytics:events>
</link>

<tabs>
  <tab>
    <label>1</label>
    <analytics:events>
      <analytics:event action="KGP Circle Toggled" system="adobe">
        <analytics:attribute key="cru.toggleswitch" value="1" />
      </analytics:event>
    </analytics:events>
  </tab>
  <tab>
    <label>2</label>
    <analytics:events>
      <analytics:event action="KGP Circle Toggled" system="adobe">
        <analytics:attribute key="cru.toggleswitch" value="2" />
      </analytics:event>
    </analytics:events>
  </tab>
</tabs>    
```

- It's possible to have multiple `<analytics:event>` nodes within a single card
  - each one would define a distinct event
- `system` defines which Analytics system the event is for
- `delay` indicates how many seconds to delay sending the analytics event.
  - Within the context of a card it could be canceled if the card becomes in-active
- `trigger` defaults to what makes sense for containing elements.
  - `<card>` defaults `trigger` to `visible`
  - `<button>`, `<link>`, and `<tab>` default `trigger` to `selected`
- an `<analytics:event>` can have multiple `<analytics:attribute>` nodes
  - The `<analytics:attribute>` node defines constant attributes that should be sent with the analytics event

TODO:
- [x] Determine other locations to support defining `<analytics:event>`