### PR TITLE
Go back to update_all to avoid callbacks

### DIFF
--- a/db/migrate/20180416210608_translations_tagline_drop_default.rb
+++ b/db/migrate/20180416210608_translations_tagline_drop_default.rb
@@ -1,6 +1,6 @@
 class TranslationsTaglineDropDefault < ActiveRecord::Migration[5.0]
   def change
     change_column_default(:translations, :translated_tagline, nil)
-    Translation.where( translated_tagline: '' ).each { |t| t.update!(translated_tagline: nil) }
+    Translation.where( translated_tagline: '' ).update_all( translated_tagline: nil )
   end
 end


### PR DESCRIPTION
updating all records with callbacks means that for every published translation, we call out to onesky and push to s3. this:
 a) takes way too long
 b) overwrites old version of pushed zips to s3. probably not a huge deal, but the versions are nice