### PR TITLE
support defining analytics events on page heroes

### DIFF
--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -138,6 +138,14 @@
                     </xs:all>
                 </xs:complexType>
             </xs:element>
+            <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Analytics events to trigger for the hero. The default trigger mode for analytics events on the
+                        hero is "visible".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <!--
                 Content section - OPTIONAL
                     text-scale: DEFAULT( 1.0 )


### PR DESCRIPTION
Sample:

```xml
<hero>
  <heading>
    <content:text>Knowing God Personally</content:text>
  </heading>
  <analytics:events>
    <analytics:event action="KGP Gospel Presented" delay="5" system="adobe" trigger="visible">
      <analytics:attribute key="cru.presentingthegospel" value="" />
    </analytics:event>
  </analytics:events>
  <content:paragraph>
  </content:paragraph>
</hero>
```