### PR TITLE
attribute keys within a single analytics event should be unique

### DIFF
--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -109,6 +109,9 @@
             </xs:attribute>
         </xs:complexType>
         <xs:unique name="uniqueAttributeKey">
+            <xs:annotation>
+                <xs:documentation>Attribute keys are unique within the context of a single event</xs:documentation>
+            </xs:annotation>
             <xs:selector xpath="analytics:attribute" />
             <xs:field xpath="@key" />
         </xs:unique>

--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -108,5 +108,9 @@
                 </xs:simpleType>
             </xs:attribute>
         </xs:complexType>
+        <xs:unique name="uniqueAttributeKey">
+            <xs:selector xpath="analytics:attribute" />
+            <xs:field xpath="@key" />
+        </xs:unique>
     </xs:element>
 </xs:schema>


### PR DESCRIPTION
This change will prevent analytics attributes from accidentally being repeated within a single event