### PR TITLE
Debug follow up issue results

### DIFF
--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -20,7 +20,7 @@ class FollowUp < ActiveRecord::Base
 
   def body
     "subscriber[route_id]=#{destination.route_id}&subscriber[language_code]=#{language.code}"\
-    "&subscriber[email]=#{email}#{names}"
+    "&subscriber[email]=#{email}#{names}#{auth_params}"
   end
 
   def names
@@ -30,10 +30,12 @@ class FollowUp < ActiveRecord::Base
     "&subscriber[first_name]=#{names[0]}&subscriber[last_name]=#{names[1]}"
   end
 
+  def auth_params
+    "&access_id=#{destination.access_key_id}&access_secret=#{destination.access_key_secret}"
+  end
+
   def headers
-    { 'Access-Id': destination.access_key_id,
-      'Access-Secret': destination.access_key_secret,
-      'Content-Type': 'application/x-www-form-urlencoded' }
+    { 'Content-Type': 'application/x-www-form-urlencoded' }
   end
 
   def perform_request

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -38,6 +38,7 @@ class FollowUp < ActiveRecord::Base
 
   def perform_request
     code = RestClient.post(destination.url, body, headers).code
+    Rails.logger.info "Received response code: #{code} from destination: #{destination.id}"
     raise Error::BadRequestError, "Received response code: #{code} from destination: #{destination.id}" if code != 201
   end
 end

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -54,27 +54,12 @@ describe FollowUp do
 
     it 'body' do
       expected = "subscriber[route_id]=#{destination.route_id}&subscriber[language_code]=#{language.code}"\
-                 "&subscriber[email]=#{email}&subscriber[first_name]=#{first_name}&subscriber[last_name]=#{last_name}"
+                 "&subscriber[email]=#{email}&subscriber[first_name]=#{first_name}&subscriber[last_name]=#{last_name}"\
+                 "&access_id=#{destination.access_key_id}&access_secret=#{destination.access_key_secret}"
 
       follow_up.send_to_api
 
       expect(RestClient).to have_received(:post).with(any_string, expected, anything)
-    end
-
-    it 'access key id' do
-      follow_up.send_to_api
-
-      expect(RestClient).to have_received(:post).with(any_string,
-                                                      anything,
-                                                      hash_including('Access-Id': destination.access_key_id))
-    end
-
-    it 'access key secret' do
-      follow_up.send_to_api
-
-      expect(RestClient).to have_received(:post).with(any_string,
-                                                      anything,
-                                                      hash_including('Access-Secret': destination.access_key_secret))
     end
   end
 


### PR DESCRIPTION
Pass access secret and id in URL as form data instead of as headers. Growthspaces was updated to handle them in this way.
Log response code for all requests