### PR TITLE
Allow images to be restricted to web or mobile devices only

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -130,6 +130,38 @@
         <xs:list itemType="content:listener" />
     </xs:simpleType>
 
+    <xs:simpleType name="deviceType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="mobile">
+                <xs:annotation>
+                    <xs:documentation>This device type represents a native app on Android or iOS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="web">
+                <xs:annotation>
+                    <xs:documentation>This device type represents a web browser</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="deviceTypes">
+        <xs:annotation>
+            <xs:documentation>A space separated list of device types</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="content:deviceType" />
+    </xs:simpleType>
+
+    <!-- common attributes -->
+    <xs:attributeGroup name="deviceRestrictions">
+        <xs:attribute name="restrictTo" type="content:deviceTypes">
+            <xs:annotation>
+                <xs:documentation>This attribute specifies that the element it is on is only rendered on the specified
+                    device types. By default elements are rendered on all devices.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
     <!-- element nodes -->
     <!-- Paragraph - Vertical stack of content with margin/padding on the top and bottom -->
     <xs:complexType name="paragraph">
@@ -200,6 +232,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="resource" type="xs:string" use="required" />
+        <xs:attributeGroup ref="content:deviceRestrictions" />
     </xs:complexType>
 
     <!-- Button -->


### PR DESCRIPTION
This will allow us to display different images for web vs mobile. The main impetus for this is that we want to render a different inline image for the knowgod.com web UI.

In order for us to utilize this for the web we will need to update the mobile apps to ignore images that are restricted to web only. Because of this need for an update to our mobile apps we may need to dialog around this and figure out if there might be a better solution available.

Example:
```xml
<content:image resource="both1.png" />
<content:image resource="both2.png" restrictTo="mobile web" />
<content:image resource="mobileInline.png" restrictTo="mobile" />
<content:image resource="webInline.png" restrictTo="web" />
```