### PR TITLE
when creating an empty manifest, utilize the correct namespace

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -54,7 +54,7 @@ class Package
   def load_or_create_manifest_node
     return load_manifest if @translation.resource.manifest.present?
 
-    @document.root = @document.create_element('manifest', 'xmlns' => 'https://mobile-content-api.cru.org/xmlns/manifest')
+    @document.root = @document.create_element('manifest', 'xmlns' => XmlUtil::XMLNS_MANIFEST)
   end
 
   def load_manifest

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -54,9 +54,7 @@ class Package
   def load_or_create_manifest_node
     return load_manifest if @translation.resource.manifest.present?
 
-    manifest = Nokogiri::XML::Node.new('manifest', @document)
-    @document.root = manifest
-    manifest
+    @document.root = @document.create_element('manifest', 'xmlns' => 'https://mobile-content-api.cru.org/xmlns/manifest')
   end
 
   def load_manifest

--- a/lib/xml_util.rb
+++ b/lib/xml_util.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module XmlUtil
+  XMLNS_MANIFEST = 'https://mobile-content-api.cru.org/xmlns/manifest'
+
   def self.translatable_nodes(xml)
     xml.xpath('//content:text[@i18n-id]')
   end
@@ -18,6 +20,6 @@ module XmlUtil
   end
 
   def self.xpath_namespace(xml, string)
-    xml.xpath("//m:#{string}", 'm' => 'https://mobile-content-api.cru.org/xmlns/manifest')
+    xml.xpath("//m:#{string}", 'm' => XMLNS_MANIFEST)
   end
 end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -129,7 +129,7 @@ describe Package do
         push
 
         manifest = load_xml(translation.manifest_name)
-        expect(manifest.xpath('/m:manifest', 'm' => 'https://mobile-content-api.cru.org/xmlns/manifest').size).to be(1)
+        expect(manifest.xpath('/m:manifest', 'm' => XmlUtil::XMLNS_MANIFEST).size).to be(1)
       end
     end
   end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -129,7 +129,7 @@ describe Package do
         push
 
         manifest = load_xml(translation.manifest_name)
-        expect(manifest.xpath('//manifest').size).to be(1)
+        expect(manifest.xpath('/m:manifest', 'm' => 'https://mobile-content-api.cru.org/xmlns/manifest').size).to be(1)
       end
     end
   end


### PR DESCRIPTION
I'm starting to refactor parts of the manifest/page xml generation process to better support some new manifest features in process. This is just a small correctness fix