### PR TITLE
add xml support for importing AEM articles

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,21 +65,10 @@ page_4_structure = '<?xml version="1.0" encoding="UTF-8" ?>
 
 is_there_god_structure = '<?xml version="1.0" encoding="UTF-8" ?>
 <article xmlns="https://mobile-content-api.cru.org/xmlns/article">
-<category>God\'s Existence</category>
-<category>Knowing God</category>
-<title>Is There a God?</title>
-<heading>Does God exist? Here are six straightforward reasons to believe that God is really there.</heading>
-<author>Marilyn Adamson</author>
-<body>Just once wouldn\'t you love for someone to simply show you the evidence for God\'s existence? No arm-twisting. No statements of, ' \
-'"You just have to believe." Well, here is an attempt to candidly offer some of the reasons which suggest that God exists.</body>
 </article>'
 
 beyond_blind_faith_structure = '<?xml version="1.0" encoding="UTF-8" ?>
 <article xmlns="https://mobile-content-api.cru.org/xmlns/article">
-<title>Beyond Blind Faith</title>
-<body>It is impossible for us to know conclusively whether God exists and what He is like unless He takes the initiative and reveals '\
-'Himself. We must scan the horizon of history to see if there is any clue to God\'s revelation. There is one clear clue. In an '\
-'obscure village in Palestine, 2,000 years ago, a Child was born in a stable. Today the entire world is still celebrating the birth of Jesus.</body>
 </article>'
 
 tract = ResourceType.find_or_create_by!(name: 'tract', dtd_file: 'tract.xsd')

--- a/public/xmlns/article.xsd
+++ b/public/xmlns/article.xsd
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           attributeFormDefault="unqualified" elementFormDefault="qualified"
-           targetNamespace="https://mobile-content-api.cru.org/xmlns/article">
-  <xs:element name="article">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="category" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-        <xs:element name="title" type="xs:string"/>
-        <xs:element name="heading" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="body" type="xs:string"/>
-      </xs:sequence>
+<xs:schema xmlns:article="https://mobile-content-api.cru.org/xmlns/article" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/article">
+
+    <xs:complexType name="aemImport">
+        <xs:attribute name="src" />
     </xs:complexType>
-  </xs:element>
+
+    <!-- exported elements and element groups -->
+    <xs:element name="article" />
+    <xs:group name="manifestElements">
+        <xs:choice>
+            <xs:element name="aem-import" minOccurs="0" maxOccurs="unbounded" type="article:aemImport" />
+        </xs:choice>
+    </xs:group>
 </xs:schema>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+<xs:schema xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
     xmlns:manifest="https://mobile-content-api.cru.org/xmlns/manifest"
     xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    attributeFormDefault="unqualified" elementFormDefault="qualified"
-    targetNamespace="https://mobile-content-api.cru.org/xmlns/manifest">
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/manifest">
 
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/article" schemaLocation="article.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/tract" schemaLocation="tract.xsd" />
 
@@ -20,9 +21,10 @@
             <xs:element name="title" minOccurs="0" maxOccurs="1" type="content:textChild" />
             <xs:element name="pages" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:choice>
                         <xs:element name="page" minOccurs="0" maxOccurs="unbounded" type="manifest:page" />
-                    </xs:sequence>
+                        <xs:group ref="article:manifestElements" />
+                    </xs:choice>
                 </xs:complexType>
             </xs:element>
             <xs:element name="resources" minOccurs="0" maxOccurs="1">

--- a/spec/acceptance/translated_pages_controller_spec.rb
+++ b/spec/acceptance/translated_pages_controller_spec.rb
@@ -7,8 +7,6 @@ resource 'TranslatedPages' do
   let(:article) do
     '<?xml version="1.0" encoding="UTF-8" ?>
 <article xmlns="https://mobile-content-api.cru.org/xmlns/article">
-<title>article</title>
-<body>article body</body>
 </article>'
   end
   let(:data) { { data: { type: :translated_page, attributes: { value: article, resource_id: 3, language_id: 2 } } } }


### PR DESCRIPTION
Sample XML:
```xml
<pages>
    <article:aem-import src="https://stage.cru.org/content/experience-fragments/questions_about_god/english" />
    <article:aem-import src="https://stage.cru.org/content/experience-fragments/questions_about_god/english/about_god" />
</pages>
```