### PR TITLE
add Appsee and Firebase to the list of support analytics system types

### DIFF
--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -15,6 +15,16 @@
                             <xs:documentation>Adobe Analytics</xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="appsee">
+                        <xs:annotation>
+                            <xs:documentation>Appsee</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="firebase">
+                        <xs:annotation>
+                            <xs:documentation>Firebase</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                     <xs:enumeration value="google">
                         <xs:annotation>
                             <xs:documentation>Google Analytics</xs:documentation>


### PR DESCRIPTION
This allows Analytics Events to be added to tract content and be triggered in certain scenarios. This could be beneficial as the team tries to identify Appsee sessions of interest.