### PR TITLE
GT-518: Support language specific manifests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ MethodLength:
   Max: 20
 
 RSpec/MultipleExpectations:
-  Max: 2
+  Max: 3
 
 RSpec/ExampleLength:
   Max: 8

--- a/Gemfile
+++ b/Gemfile
@@ -32,21 +32,16 @@ gem 'syslog-logger'
 gem 'active_model_serializers', '= 0.10.5'
 gem 'aws-sdk'
 gem 'aws-sdk-rails'
-gem 'codecov', require: false
 gem 'ddtrace'
 gem 'loofah', '~> 2.2.1'
 gem 'nokogiri', '>= 1.8.5'
 gem 'oj', '~> 2.12.14'
 gem 'paperclip'
 gem 'pg'
-gem 'raddocs'
 gem 'rails-html-sanitizer', '>= 1.0.4'
 gem 'rest-client', '~> 2.0.1'
 gem 'rollbar'
-gem 'rspec_api_documentation'
-gem 'rubocop-rspec'
 gem 'rubyzip', '>= 1.2.2'
-gem 'sinatra', '~> 2.0.2'
 gem 'validates_email_format_of'
 
 # Use Capistrano for deployment
@@ -55,16 +50,21 @@ gem 'validates_email_format_of'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'codecov', require: false
   gem 'dotenv-rails'
   gem 'equivalent-xml', '~> 0.6.0'
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'rspec'
   gem 'rspec-rails', '~> 3.4'
+  gem 'rspec_api_documentation', require: false
   gem 'rubocop', '~> 0.49.0', require: false
+  gem 'rubocop-rspec', require: false
   gem 'simplecov', require: false
   gem 'webmock', require: false
 end
+
+gem 'raddocs'
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :development, :test do
   gem 'guard-rubocop'
   gem 'rspec'
   gem 'rspec-rails', '~> 3.4'
-  gem 'rspec_api_documentation', require: false
+  gem 'rspec_api_documentation'
   gem 'rubocop', '~> 0.49.0', require: false
   gem 'rubocop-rspec', require: false
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,6 @@ DEPENDENCIES
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
   simplecov
-  sinatra (~> 2.0.2)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/app/controllers/custom_manifests_controller.rb
+++ b/app/controllers/custom_manifests_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class CustomManifestsController < SecureController
+  def create
+    manifest = find_manifest
+    if manifest
+      update_manifest(manifest)
+    else
+      create_manifest
+    end
+  end
+
+  def update
+    manifest = find_manifest
+    update_manifest(manifest)
+  end
+
+  def destroy
+    manifest = find_manifest
+    manifest.destroy!
+    head :no_content
+  end
+
+  def show
+    manifest = find_manifest
+    render json: manifest, status: :ok
+  end
+
+  private
+
+  def find_manifest
+    if params[:id]
+      CustomManifest.find(params[:id])
+    else
+      CustomManifest.find_by(language_id: data_attrs[:language_id], resource_id: data_attrs[:resource_id])
+    end
+  end
+
+  def create_manifest
+    manifest = CustomManifest.create!(permit_params(:language_id, :resource_id, :structure))
+    render json: manifest, status: :created, location: custom_manifest_path(manifest)
+  end
+
+  def update_manifest(manifest)
+    manifest.update!(permit_params(:structure))
+    render json: manifest, status: :ok
+  end
+end

--- a/app/models/custom_manifest.rb
+++ b/app/models/custom_manifest.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CustomManifest < ApplicationRecord
+  belongs_to :language
+  belongs_to :resource
+
+  validates :resource, presence: true
+  validates :language, presence: true, uniqueness: { scope: :resource }
+
+  validates :structure, xml: true, if: :structure?
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -9,6 +9,7 @@ class Resource < ActiveRecord::Base
   has_many :views
   has_many :attachments
   has_many :translated_pages
+  has_many :custom_manifests
 
   validates :name, presence: true
   validates :abbreviation, presence: true, uniqueness: true

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -54,6 +54,12 @@ class Translation < ActiveRecord::Base
     order(version: :desc).find_by(resource_id: resource_id, language_id: language_id)
   end
 
+  # Returns the manifest (XML) content to use for this translation (language).
+  # @return [String] or nil if no manifest exists
+  def resolve_manifest
+    resource.custom_manifests.find_by(language_id: language_id)&.structure || resource.manifest
+  end
+
   def manifest_translated_phrases
     @manifest_translated_phrases ||= download_translated_phrases('name_description.xml')
   end

--- a/app/models/xml/manifest.rb
+++ b/app/models/xml/manifest.rb
@@ -9,7 +9,7 @@ module XML
     def initialize(translation)
       @translation = translation
 
-      @document = Nokogiri::XML(@translation.resource.manifest)
+      @document = Nokogiri::XML(@translation.resolve_manifest)
       @document.root = create_manifest if @document.root.nil?
 
       manifest_node = @document.root

--- a/app/models/xml/manifest.rb
+++ b/app/models/xml/manifest.rb
@@ -57,7 +57,9 @@ module XML
       title_node = XmlUtil.xpath_namespace(manifest_node, 'manifest:title').first
       return if title_node.nil?
 
-      name_node = title_node.xpath('content:text[@i18n-id]').first
+      name_node = title_node.xpath('content:text[@i18n-id]')&.first
+      return if name_node.nil?
+
       name_node.attributes['i18n-id'].value
     end
 

--- a/app/serializers/custom_manifest_serializer.rb
+++ b/app/serializers/custom_manifest_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CustomManifestSerializer < ActiveModel::Serializer
+  type 'custom-manifest'
+  attributes :id, :structure
+
+  belongs_to :resource
+  belongs_to :language
+end

--- a/app/validators/xml_validator.rb
+++ b/app/validators/xml_validator.rb
@@ -15,7 +15,7 @@ class XmlValidator < ActiveModel::EachValidator
   end
 
   def xsd_location(record)
-    return 'manifest.xsd' if record.is_a?(Resource)
+    return 'manifest.xsd' if record.is_a?(Resource) || record.is_a?(CustomManifest)
     return record.resource.resource_type.dtd_file if record.is_a?(Page) || record.is_a?(TranslatedPage)
     return record.page.resource.resource_type.dtd_file if record.is_a?(CustomPage)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
 
   resources :auth, only: [:create, :show]
 
+  resources :custom_manifests, only: [:create, :update, :destroy, :show]
+
   get 'monitors/lb'
   get 'monitors/commit'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,26 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :systems, :auth, :translations, :drafts, :resources, :custom_pages, :languages, :attributes,
-            :translated_attributes, :pages, :views, :attachments, :translated_pages, :follow_ups, :resource_types
+  resources :systems, only: [:index, :show]
+  resources :languages
+  resources :resource_types, only: [:index, :show]
+
+  resources :resources
+  resources :drafts
+  resources :translations, only: [:index, :show]
+  resources :pages, only: [:create, :update, :show]
+  resources :custom_pages, only: [:create, :update, :destroy, :show]
+
+  resources :attributes, only: [:create, :update, :destroy, :show]
+  resources :translated_attributes, only: [:create, :update, :destroy, :show]
+  resources :translated_pages, only: [:create, :update, :destroy, :show]
+
+  resources :views, only: [:create]
+  resources :follow_ups, only: [:create]
+
+  resources :attachments
+
+  resources :auth, only: [:create, :show]
 
   get 'monitors/lb'
   get 'monitors/commit'

--- a/db/migrate/20190716115741_custom_manifests_per_language.rb
+++ b/db/migrate/20190716115741_custom_manifests_per_language.rb
@@ -1,0 +1,12 @@
+class CustomManifestsPerLanguage < ActiveRecord::Migration[5.0]
+  def change
+    create_table :custom_manifests do |t|
+      t.string :structure, null: false
+      t.references :resource, null: false, foreign_key: true
+      t.references :language, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :custom_manifests, [:resource_id, :language_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180416210608) do
+ActiveRecord::Schema.define(version: 20190716115741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,17 @@ ActiveRecord::Schema.define(version: 20180416210608) do
     t.datetime "expiration",     default: '2016-01-01 01:00:00', null: false
     t.index ["access_code_id"], name: "index_auth_tokens_on_access_code_id", using: :btree
     t.index ["token"], name: "index_auth_tokens_on_token", unique: true, using: :btree
+  end
+
+  create_table "custom_manifests", force: :cascade do |t|
+    t.string   "structure",   null: false
+    t.integer  "resource_id", null: false
+    t.integer  "language_id", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["language_id"], name: "index_custom_manifests_on_language_id", using: :btree
+    t.index ["resource_id", "language_id"], name: "index_custom_manifests_on_resource_id_and_language_id", unique: true, using: :btree
+    t.index ["resource_id"], name: "index_custom_manifests_on_resource_id", using: :btree
   end
 
   create_table "custom_pages", force: :cascade do |t|
@@ -154,6 +165,8 @@ ActiveRecord::Schema.define(version: 20180416210608) do
   add_foreign_key "attachments", "resources"
   add_foreign_key "attributes", "resources"
   add_foreign_key "auth_tokens", "access_codes"
+  add_foreign_key "custom_manifests", "languages"
+  add_foreign_key "custom_manifests", "resources"
   add_foreign_key "custom_pages", "languages"
   add_foreign_key "custom_pages", "pages"
   add_foreign_key "follow_ups", "destinations"

--- a/spec/acceptance/auth_controller_spec.rb
+++ b/spec/acceptance/auth_controller_spec.rb
@@ -5,18 +5,19 @@ require 'acceptance_helper'
 resource 'Auth' do
   header 'Accept', 'application/vnd.api+json'
   header 'Content-Type', 'application/vnd.api+json'
+  let(:type) { 'auth-token' }
   let(:raw_post) { params.to_json }
   let(:valid_code) { 123_456 }
 
   post 'auth/' do
     it 'create a token with valid code' do
-      do_request data: { type: :auth_token, attributes: { code: valid_code } }
+      do_request data: { type: type, attributes: { code: valid_code } }
 
       expect(status).to be(201)
     end
 
     it 'create a token with invalid code' do
-      do_request data: { type: :auth_token, attributes: { code: 999_999 } }
+      do_request data: { type: type, attributes: { code: 999_999 } }
 
       expect(status).to be(400)
     end
@@ -26,7 +27,7 @@ resource 'Auth' do
         receive(:find_by).with(code: valid_code).and_return(AccessCode.new(expiration: DateTime.now.utc - 1.second))
       )
 
-      do_request data: { type: :auth_token, attributes: { code: valid_code } }
+      do_request data: { type: type, attributes: { code: valid_code } }
 
       expect(status).to be(400)
     end

--- a/spec/acceptance/custom_manifests_controller_spec.rb
+++ b/spec/acceptance/custom_manifests_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+resource 'CustomManifests' do
+  header 'Accept', 'application/vnd.api+json'
+  header 'Content-Type', 'application/vnd.api+json'
+
+  let(:raw_post) { params.to_json }
+  let(:structure) do
+    '<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title><content:text i18n-id="name">About God</content:text></title>
+</manifest>'
+  end
+
+  let(:access_code) { AccessCode.find(1) }
+  let(:authorization) do
+    AuthToken.create!(access_code: access_code).token
+  end
+
+  let(:resource) { Resource.first }
+  let(:language) { Language.first }
+
+  let(:empty_structure) do
+    '<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+</manifest>'
+  end
+
+  let(:a_custom_manifest) do
+    resource.custom_manifests.where(language: language).first ||
+      resource.custom_manifests.create!(language: language, structure: empty_structure)
+  end
+
+  before do
+    header 'Authorization', :authorization
+  end
+
+  post 'custom_manifests/' do
+    requires_authorization
+
+    it 'creates a custom manifest' do
+      attrs = { language_id: language.id, resource_id: resource.id, structure: structure }
+      do_request data: { type: :custom_manifest, attributes: attrs }
+
+      expect(status).to be(201)
+
+      expect(JSON.parse(response_body)['data']).not_to be_nil
+      expect(response_headers['Location']).to match(%r{custom_manifests\/\d+})
+    end
+
+    it 'updates a custom manifest' do
+      a_custom_manifest
+      attrs = { language_id: language.id, resource_id: resource.id, structure: structure }
+      do_request data: { attributes: attrs }
+
+      expect(status).to be(200)
+      expect(JSON.parse(response_body)['data']).not_to be_nil
+    end
+  end
+
+  put 'custom_manifests/:id' do
+    let(:id) { a_custom_manifest.id }
+
+    requires_authorization
+
+    it 'updates a custom manifest' do
+      attrs = { structure: structure }
+      do_request data: { type: :custom_manifest, attributes: attrs }
+
+      expect(status).to be(200)
+      expect(JSON.parse(response_body)['data']).not_to be_nil
+    end
+  end
+
+  delete 'custom_manifests/:id' do
+    let(:id) { a_custom_manifest.id }
+
+    requires_authorization
+
+    it 'delete a custom manifest' do
+      do_request
+
+      expect(status).to be(204)
+      expect(response_body).to be_empty
+    end
+  end
+end

--- a/spec/acceptance/custom_manifests_controller_spec.rb
+++ b/spec/acceptance/custom_manifests_controller_spec.rb
@@ -45,7 +45,7 @@ resource 'CustomManifests' do
 
     it 'creates a custom manifest' do
       attrs = { language_id: language.id, resource_id: resource.id, structure: structure }
-      do_request data: { type: :custom_manifest, attributes: attrs }
+      do_request data: { type: type, attributes: attrs }
 
       expect(status).to be(201)
 
@@ -70,7 +70,7 @@ resource 'CustomManifests' do
 
     it 'updates a custom manifest' do
       attrs = { structure: structure }
-      do_request data: { type: :custom_manifest, attributes: attrs }
+      do_request data: { type: type, attributes: attrs }
 
       expect(status).to be(200)
       expect(JSON.parse(response_body)['data']).not_to be_nil

--- a/spec/acceptance/custom_manifests_controller_spec.rb
+++ b/spec/acceptance/custom_manifests_controller_spec.rb
@@ -59,7 +59,7 @@ resource 'CustomManifests' do
       do_request data: { attributes: attrs }
 
       expect(status).to be(200)
-      expect(JSON.parse(response_body)['data']).not_to be_nil
+      expect(JSON.parse(response_body)['data']).not_to be nil
     end
   end
 
@@ -73,7 +73,7 @@ resource 'CustomManifests' do
       do_request data: { type: type, attributes: attrs }
 
       expect(status).to be(200)
-      expect(JSON.parse(response_body)['data']).not_to be_nil
+      expect(JSON.parse(response_body)['data']).not_to be nil
     end
   end
 
@@ -87,6 +87,21 @@ resource 'CustomManifests' do
 
       expect(status).to be(204)
       expect(response_body).to be_empty
+    end
+  end
+
+  get 'custom_manifests/:id' do
+    let(:id) { a_custom_manifest.id }
+
+    requires_authorization
+
+    it 'retrieves a custom manifest' do
+      do_request
+
+      expect(status).to be(200)
+      data = JSON.parse(response_body)['data']
+      expect(data['id'].to_i).to eql id
+      expect(data['type']).to eql 'custom-manifest'
     end
   end
 end

--- a/spec/acceptance/custom_pages_controller_spec.rb
+++ b/spec/acceptance/custom_pages_controller_spec.rb
@@ -28,21 +28,21 @@ resource 'CustomPages' do
       let(:attrs) { { language_id: 3, page_id: 2, structure: structure } }
 
       it 'create a custom page' do
-        do_request data: { type: :custom_page, attributes: attrs }
+        do_request data: { type: type, attributes: attrs }
 
         expect(status).to be(201)
         expect(JSON.parse(response_body)['data']).not_to be_nil
       end
 
       it 'creating sets location header', document: false do
-        do_request data: { type: :custom_page, attributes: attrs }
+        do_request data: { type: type, attributes: attrs }
 
         expect(response_headers['Location']).to match(%r{custom_pages\/\d+})
       end
     end
 
     it 'update a custom page' do
-      do_request data: { type: :custom_page,
+      do_request data: { type: type,
                          attributes: { language_id: 2, page_id: 1, structure: structure } }
 
       expect(status).to be(200)

--- a/spec/acceptance/follow_ups_controller_spec.rb
+++ b/spec/acceptance/follow_ups_controller_spec.rb
@@ -2,14 +2,14 @@
 
 require 'acceptance_helper'
 
-resource 'Follow Ups' do
+resource 'FollowUps' do
   header 'Accept', 'application/vnd.api+json'
   header 'Content-Type', 'application/vnd.api+json'
   let(:raw_post) { params.to_json }
 
   post 'follow_ups/' do
     let(:data) do
-      { type: :follow_up,
+      { type: type,
         attributes: { name: 'Billy Bob', email: 'bob@test.com', language_id: 2, destination_id: 1 } }
     end
 

--- a/spec/acceptance/languages_controller_spec.rb
+++ b/spec/acceptance/languages_controller_spec.rb
@@ -56,26 +56,26 @@ resource 'Languages' do
     it 'cannot duplicate code', document: false do
       code = 'en'
 
-      do_request data: { type: :language, attributes: { name: 'another English', code: code } }
+      do_request data: { type: type, attributes: { name: 'another English', code: code } }
 
       expect(status).to be(400)
       expect(JSON.parse(response_body)['errors'][0]['detail']).to eq("Code #{code} already exists.")
     end
 
     it 'defaults direction to ltr', document: false do
-      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev' } }
+      do_request data: { type: type, attributes: { name: 'Elvish', code: 'ev' } }
 
       expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq('ltr')
     end
 
     it 'honors direction when set to rtl', document: false do
-      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'rtl' } }
+      do_request data: { type: type, attributes: { name: 'Elvish', code: 'ev', direction: 'rtl' } }
 
       expect(JSON.parse(response_body)['data']['attributes']['direction']).to eq('rtl')
     end
 
     it 'fails on invalid direction value', document: false do
-      do_request data: { type: :language, attributes: { name: 'Elvish', code: 'ev', direction: 'bogus' } }
+      do_request data: { type: type, attributes: { name: 'Elvish', code: 'ev', direction: 'bogus' } }
 
       error = "Validation failed: Bogus Invalid direction bogus. Valid values for direction are 'ltr' and 'rtl'"
       expect(status).to be(400)

--- a/spec/acceptance/translated_attributes_controller_spec.rb
+++ b/spec/acceptance/translated_attributes_controller_spec.rb
@@ -28,14 +28,14 @@ resource 'TranslatedAttributes' do
     requires_authorization
 
     it 'create a Translated Attribute' do
-      do_request data: { type: :translated_attribute, attributes: attrs }
+      do_request data: { type: type, attributes: attrs }
 
       expect(status).to be(204)
       expect(response_body).to be_empty
     end
 
     it 'sets location header', document: false do
-      do_request data: { type: :translated_attribute, attributes: attrs }
+      do_request data: { type: type, attributes: attrs }
 
       expect(response_headers['Location']).to eq("translated_attributes/#{id}")
     end
@@ -53,7 +53,7 @@ resource 'TranslatedAttributes' do
       attribute = instance_double(TranslatedAttribute, update!: nil)
       allow(TranslatedAttribute).to receive(:find).and_return(attribute)
 
-      do_request data: { type: :translated_attribute, attributes: attrs }
+      do_request data: { type: type, attributes: attrs }
 
       expect(status).to be(204)
       expect(response_body).to be_empty

--- a/spec/acceptance/translated_pages_controller_spec.rb
+++ b/spec/acceptance/translated_pages_controller_spec.rb
@@ -9,7 +9,7 @@ resource 'TranslatedPages' do
 <article xmlns="https://mobile-content-api.cru.org/xmlns/article">
 </article>'
   end
-  let(:data) { { data: { type: :translated_page, attributes: { value: article, resource_id: 3, language_id: 2 } } } }
+  let(:data) { { data: { type: 'translated-page', attributes: { value: article, resource_id: 3, language_id: 2 } } } }
 
   before do
     header 'Authorization', :authorization

--- a/spec/models/custom_manifest_spec.rb
+++ b/spec/models/custom_manifest_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomManifest, type: :model do
+  let(:structure) do
+    '<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title><content:text i18n-id="name">About God</content:text></title>
+</manifest>'
+  end
+
+  let(:resource) { Resource.first }
+  let(:language) { Language.first }
+
+  let(:empty_structure) do
+    '<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title><content:text i18n-id="title"></content:text></title>
+</manifest>'
+  end
+
+  it 'cannot have a duplicate for resource and language' do
+    described_class.create!(resource_id: resource.id, language_id: language.id, structure: structure)
+    t = described_class.create(resource_id: resource.id, language_id: language.id, structure: structure)
+
+    expect(t.errors['language']).to include('has already been taken')
+  end
+
+  it 'updates structure' do
+    t = described_class.create!(resource_id: resource.id, language_id: language.id, structure: structure)
+    t.update!(structure: empty_structure)
+
+    expect(t.reload.structure).to include('i18n-id="title"')
+  end
+
+  it 'validates (XML) structure' do
+    t = described_class.create(resource_id: resource.id, language_id: language.id, structure: '<invalid>XML')
+
+    expect(t.errors['structure']).not_to be_empty
+  end
+end

--- a/spec/models/xml/manifest_spec.rb
+++ b/spec/models/xml/manifest_spec.rb
@@ -123,6 +123,40 @@ describe XML::Manifest do
         expect(result.first.content).to eq('O Bohu')
         expect(result.last.content).to eq('Všetko Ostatné')
       end
+
+      context 'resource has custom manifest for language' do
+        let(:custom_manifest_structure) do
+'<?xml version="1.0"?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+          category-label-color="rgba(255,255,255,1)">
+    <title><content:text i18n-id="name">About God</content:text></title>
+    <categories>
+        <category id="about-god" banner="banner-about-god-custom.jpg">
+           <label>
+               <content:text i18n-id="about_god">The LORD</content:text>
+           </label>
+        </category>
+    </categories>
+</manifest>'
+        end
+        let(:language) { translation.language }
+        let(:custom_manifest) do
+          translation.resource.custom_manifests.create! language: language, structure: custom_manifest_structure
+        end
+
+        it 'is using custom manifest structure' do
+          custom_manifest
+          expect(manifest.document.to_s).to include('banner-about-god-custom.jpg')
+        end
+
+        it 'translates category content' do
+          custom_manifest
+          result = XmlUtil.xpath_namespace(manifest.document, '//manifest:category/manifest:label/content:text')
+          expect(result.first.content).to eq('O Bohu')
+        end
+      end
     end
 
     context 'resource does not have a manifest file' do

--- a/spec/models/xml/manifest_spec.rb
+++ b/spec/models/xml/manifest_spec.rb
@@ -182,5 +182,39 @@ describe XML::Manifest do
         expect(result).to be_nil
       end
     end
+
+    context 'resource has a custom manifest without i18n-id attribute' do
+      let(:translation) do
+        t = Translation.find(1)
+        t.resource.manifest = '<?xml version="1.0"?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title><content:text i18n-id="name">Questions about God</content:text></title>
+</manifest>'
+        allow(t).to(receive(:translated_name).and_return('*Questions about God*'))
+        allow(t).to(receive(:manifest_translated_phrases).and_return({}))
+
+        t
+      end
+
+      let(:custom_manifest_structure) do
+        '<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+          xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+          xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title><content:text>Renderer Testing (es)</content:text></title>
+</manifest>'
+      end
+      let(:language) { translation.language }
+      let(:custom_manifest) do
+        translation.resource.custom_manifests.create! language: language, structure: custom_manifest_structure
+      end
+
+      it 'uses custom manifest structure' do
+        custom_manifest
+        expect(manifest.document.to_s).to include('Renderer Testing (es)')
+      end
+    end
   end
 end


### PR DESCRIPTION
a custom manifest might be set for a given language and resource
in that sense its unique - only one can exists for given (resource_id, language_id)

builds on top of [(GT-517)](https://github.com/CruGlobal/mobile-content-api/pull/179)

re-arranged routes (to skip some unused ones -> returned 404 will be the same) 
and moved gems under their proper development/test section

*NOTE: includes a commit from #179 (will rebase after its merged)*