### PR TITLE
[fix] do proper true/false param conversion

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,18 @@ class ApplicationController < ActionController::Base
     params.merge!(ActiveSupport::JSON.decode(request.body.string))
   end
 
+  # Get a parameter as a boolean value.
+  # 'false', '0' (or if param is not present) are false-y.
+  # @return [true, false]
+  def param?(name)
+    case (param = params[name.to_s].to_s)
+    when 'true' then true
+    when 'false' then false
+    else
+      !param.to_f.zero? # '0', '0.0' => false, '0.1', '1' => true
+    end
+  end
+
   class ApiError
     include ActiveModel::Model
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,15 +67,18 @@ class ApplicationController < ActionController::Base
     params.merge!(ActiveSupport::JSON.decode(request.body.string))
   end
 
+  FALSE_VALUES = ActiveModel::Type::Boolean::FALSE_VALUES
+  private_constant :FALSE_VALUES
+
   # Get a parameter as a boolean value.
   # 'false', '0' (or if param is not present) are false-y.
   # @return [true, false]
   def param?(name)
-    case (param = params[name.to_s].to_s)
-    when 'true' then true
-    when 'false' then false
+    param = params[name.to_s]
+    if param.to_s.blank?
+      nil
     else
-      !param.to_f.zero? # '0', '0.0' => false, '0.1', '1' => true
+      !FALSE_VALUES.include?(param)
     end
   end
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -24,7 +24,7 @@ class ResourcesController < ApplicationController
   end
 
   def push_to_onesky # TODO: this could be done for individual pages when their structure is updated
-    PageClient.new(load_resource, 'en').push_new_onesky_translation(params['keep-existing-phrases'])
+    PageClient.new(load_resource, 'en').push_new_onesky_translation param?('keep-existing-phrases')
 
     head :no_content
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,20 +1,77 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'puma/null_io'
 
 describe ApplicationController do
   controller do
-    def index; end
+    def index
+      head(204)
+    end
+    public :param?, :params
+  end
+
+  before(:all) do
+    Mime::Type.register 'application/vnd.api+json', :json_api
   end
 
   it 'params are not merged if no body' do
-    Mime::Type.register 'application/vnd.api+json', :json_api
-    request.headers['REQUEST-METHOD'] = 'DELETE'
-    request.headers['Content-Type'] = 'application/vnd.api+json'
+    set_method_and_jsonapi_headers 'DELETE'
 
     delete :index, body: String.new('')
 
     expect(response).to have_http_status(:no_content)
+  end
+
+  it 'empty and missing params are false-y' do
+    set_method_and_jsonapi_headers 'GET'
+
+    get :index, params: { foo: '', bar: '   ' }
+
+    expect(controller.param?(:foo)).to be_falsey
+    expect(controller.param?('bar')).to be_falsey
+    expect(controller.param?(:baz)).to be_falsey
+  end
+
+  it 'zero params are false-y' do
+    set_method_and_jsonapi_headers 'GET'
+
+    get :index, params: { 'foo' => '0', 'bar' => 0 }
+
+    expect(controller.param?(:foo)).to be_falsey
+    expect(controller.param?(:bar)).to be_falsey
+  end
+
+  it 'non-zero params are truthy-y' do
+    set_method_and_jsonapi_headers 'GET'
+
+    get :index, params: { 'foo' => '1', 'bar' => 1, :baz => '01' }
+
+    expect(controller.param?(:foo)).to be true
+    expect(controller.param?(:bar)).to be true
+    expect(controller.param?(:baz)).to be true
+  end
+
+  it 'non-blank strings are truthy-y' do
+    set_method_and_jsonapi_headers 'GET'
+
+    get :index, params: { 'foo' => 'X', 'bar' => ' . ', :baz => '[]' }
+
+    expect(controller.param?(:foo)).to be true
+    expect(controller.param?(:bar)).to be true
+    expect(controller.param?(:baz)).to be true
+  end
+
+  it 'true/false params are converted to boolean' do
+    set_method_and_jsonapi_headers 'GET'
+
+    get :index, params: { 'foo' => 'true', 'bar' => 'false' }
+
+    expect(controller.param?(:foo)).to be true
+    expect(controller.param?(:bar)).to be false
+  end
+
+  def set_method_and_jsonapi_headers(method = 'GET')
+    request.headers['REQUEST-METHOD'] = method
+    request.headers['Content-Type'] = 'application/vnd.api+json'
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -10,6 +10,7 @@ describe ApplicationController do
     public :param?, :params
   end
 
+  # rubocop: disable BeforeAfterAll
   before(:all) do
     Mime::Type.register 'application/vnd.api+json', :json_api
   end
@@ -70,6 +71,7 @@ describe ApplicationController do
     expect(controller.param?(:bar)).to be false
   end
 
+  # rubocop:disable AccessorMethodName
   def set_method_and_jsonapi_headers(method = 'GET')
     request.headers['REQUEST-METHOD'] = method
     request.headers['Content-Type'] = 'application/vnd.api+json'


### PR DESCRIPTION
as currently **PUT /resources/1/onesky** *keep-existing-phrases=false*
will end up doing a `push_new_onesky_translation(keep_existing_phrases = true)`