### PR TITLE
export custom-manifests association on resource

### DIFF
--- a/app/controllers/custom_manifests_controller.rb
+++ b/app/controllers/custom_manifests_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CustomManifestsController < SecureController
+  skip_before_action :authorize!, only: [:show]
+
   def create
     manifest = find_manifest
     if manifest

--- a/app/serializers/resource_serializer.rb
+++ b/app/serializers/resource_serializer.rb
@@ -12,6 +12,7 @@ class ResourceSerializer < ActiveModel::Serializer
   has_many :latest_drafts_translations, key: 'latest_drafts_translations'
   has_many :pages
   has_many :attachments
+  has_many :custom_manifests, key: 'custom-manifests'
 
   def attributes(*args)
     hash = super

--- a/spec/acceptance/attributes_controller_spec.rb
+++ b/spec/acceptance/attributes_controller_spec.rb
@@ -10,10 +10,6 @@ resource 'Attributes' do
     AuthToken.create!(access_code: AccessCode.find(1)).token
   end
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   post 'attributes/' do
     let(:data) { { type: :attribute, attributes: { key: 'foo', value: 'bar', resource_id: 1 } } }
 

--- a/spec/acceptance/custom_manifests_controller_spec.rb
+++ b/spec/acceptance/custom_manifests_controller_spec.rb
@@ -89,8 +89,6 @@ resource 'CustomManifests' do
   get 'custom_manifests/:id' do
     let(:id) { a_custom_manifest.id }
 
-    requires_authorization
-
     it 'retrieves a custom manifest' do
       do_request
 

--- a/spec/acceptance/custom_manifests_controller_spec.rb
+++ b/spec/acceptance/custom_manifests_controller_spec.rb
@@ -36,10 +36,6 @@ resource 'CustomManifests' do
       resource.custom_manifests.create!(language: language, structure: empty_structure)
   end
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   post 'custom_manifests/' do
     requires_authorization
 

--- a/spec/acceptance/custom_pages_controller_spec.rb
+++ b/spec/acceptance/custom_pages_controller_spec.rb
@@ -13,12 +13,9 @@ resource 'CustomPages' do
       xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
 </page>'
   end
+
   let(:authorization) do
     AuthToken.create!(access_code: AccessCode.find(1)).token
-  end
-
-  before do
-    header 'Authorization', :authorization
   end
 
   post 'custom_pages/' do

--- a/spec/acceptance/drafts_controller_spec.rb
+++ b/spec/acceptance/drafts_controller_spec.rb
@@ -11,10 +11,6 @@ resource 'Drafts' do
     AuthToken.create!(access_code: AccessCode.find(1)).token
   end
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   get 'drafts/' do
     requires_authorization
 

--- a/spec/acceptance/languages_controller_spec.rb
+++ b/spec/acceptance/languages_controller_spec.rb
@@ -34,10 +34,6 @@ resource 'Languages' do
   end
 
   post 'languages' do
-    before do
-      header 'Authorization', :authorization
-    end
-
     requires_authorization
 
     it 'create a language' do

--- a/spec/acceptance/pages_controller_spec.rb
+++ b/spec/acceptance/pages_controller_spec.rb
@@ -10,10 +10,6 @@ resource 'Pages' do
   let(:authorization) { AuthToken.create!(access_code: AccessCode.find(1)).token }
   let(:test_structure) { '<?xml version="1.0" encoding="UTF-8" ?><page> new page </page>' }
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   post 'pages' do
     let(:attrs) { { filename: 'test.xml', structure: test_structure, resource_id: 2, position: 1 } }
 

--- a/spec/acceptance/resources_controller_spec.rb
+++ b/spec/acceptance/resources_controller_spec.rb
@@ -105,10 +105,6 @@ resource 'Resources' do
        </manifest>'
     end
 
-    before do
-      header 'Authorization', :authorization
-    end
-
     put 'resources/:id' do
       requires_authorization
 

--- a/spec/acceptance/translated_attributes_controller_spec.rb
+++ b/spec/acceptance/translated_attributes_controller_spec.rb
@@ -11,10 +11,6 @@ resource 'TranslatedAttributes' do
     AuthToken.create!(access_code: AccessCode.find(1)).token
   end
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   post 'translated_attributes' do
     let(:attrs) do
       { attribute_id: 2, translation_id: 2, value: 'translated attr' }

--- a/spec/acceptance/translated_pages_controller_spec.rb
+++ b/spec/acceptance/translated_pages_controller_spec.rb
@@ -11,10 +11,6 @@ resource 'TranslatedPages' do
   end
   let(:data) { { data: { type: 'translated-page', attributes: { value: article, resource_id: 3, language_id: 2 } } } }
 
-  before do
-    header 'Authorization', :authorization
-  end
-
   post 'translated_pages/' do
     requires_authorization
 

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -11,6 +11,14 @@ end
 RSpec.configure do |config|
   config.extend(Module.new do
     def requires_authorization
+      before do
+        header 'Authorization', :authorization
+      end
+
+      after do
+        header 'Authorization', nil
+      end
+
       it 'must send a token', document: false do
         blank
       end


### PR DESCRIPTION
follow-up on #181 

really just: https://github.com/CruGlobal/mobile-content-api/compare/GT-518+include?expand=1#diff-032d1ef5aa2c930497d19dbe702d814cR15

but I keep finding surprises - acceptance tests were keeping the authorization header for the whole unit