### PR TITLE
GT-698: [step-1] Allow a GodTools user to sign up for content hosted in Adobe Campaigns

### DIFF
--- a/db/migrate/20200220150100_add_service_type_to_destination.rb
+++ b/db/migrate/20200220150100_add_service_type_to_destination.rb
@@ -1,0 +1,21 @@
+class AddServiceTypeToDestination < ActiveRecord::Migration[5.2]
+  def up
+    add_column :destinations, :service_type, :string
+    add_column :destinations, :service_name, :string
+
+    Destination.reset_column_information
+    Destination.update_all service_type: :growth_spaces
+
+    Destination.create! url: "https://mc.adobe.io/",
+                        service_type: :adobe_campaigns,
+                        service_name: "GodTools New Growth Series"
+
+    change_column_null :destinations, :service_type, false
+  end
+
+  def down
+    Destination.where(service_type: :adobe_campaigns).destroy_all
+    remove_column :destinations, :service_type
+    remove_column :destinations, :service_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_152056) do
+ActiveRecord::Schema.define(version: 2020_02_20_150100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,8 @@ ActiveRecord::Schema.define(version: 2019_11_20_152056) do
     t.string "route_id"
     t.string "access_key_id"
     t.string "access_key_secret"
+    t.string "service_type", null: false
+    t.string "service_name"
   end
 
   create_table "follow_ups", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -133,4 +133,5 @@ Attachment.create!(resource: kgp, file: Rack::Test::UploadedFile.new("spec/fixtu
 Attachment.create!(resource: kgp, file: Rack::Test::UploadedFile.new("spec/fixtures/web_mobile.png", "image/png"))
 Attachment.create!(resource: kgp, file: Rack::Test::UploadedFile.new("spec/fixtures/both.png", "image/png"), is_zipped: true)
 
-Destination.find_or_create_by!(url: "myapi.org", route_id: "100", access_key_id: "12345", access_key_secret: "hello, world!!")
+Destination.find_or_create_by!(service_type: :growth_spaces, url: "myapi.org", route_id: "100", access_key_id: "12345", access_key_secret: "hello, world!!")
+Destination.find_or_create_by!(service_type: :adobe_campaigns, url: "https://mc.adobe.io/", service_name: "GodTools New Growth Series", access_key_id: "67890", access_key_secret: "this is a secret")


### PR DESCRIPTION
This is the first of two PRs, the first one adds adobe related fields to the destinations table, allowing them to be filled up before deploying further changes (which will require this information).

https://jira.cru.org/browse/GT-698
