### PR TITLE
validate the XML schemas with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,5 @@ jobs:
     script:
     - xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/*/*.xml
     - xmllint --schema public/xmlns/tract.xsd --noout schema_tests/tract/valid/*/*.xml
+    # text invalid XML
+    - ./schema_tests/invalid.sh public/xmlns/tract.xsd schema_tests/tract/invalid/*/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,29 @@
-sudo: false
-language: ruby
-
-addons:
-  postgresql: 9.6
-
-cache:
-  bundler: true
-
-before_script:
-  - bundle exec rake db:create db:setup RAILS_ENV=test
-
-script:
-  - bundle exec rake spec
-  - bundle exec standardrb
-  - bundle exec bundle audit check --update
-  - bundle exec brakeman -A -q --no-pager --ensure-latest
-
 jobs:
   include:
-  - name: "XML Schema Validation"
-    before_script: skip
+  - language: ruby
+
+    addons:
+      postgresql: 9.6
+
+    cache:
+      bundler: true
+
+    before_script: 
+    - bundle exec rake db:create db:setup RAILS_ENV=test
+
     script:
-    - xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/*.xml
+    - bundle exec rake spec
+    - bundle exec standardrb
+    - bundle exec bundle audit check --update
+    - bundle exec brakeman -A -q --no-pager --ensure-latest
+
+  - name: "XML Schema Validation"
+
+    addons:
+      apt:
+        packages:
+        - libxml2-utils
+
+    script:
+    - xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/*/*.xml
     - xmllint --schema public/xmlns/tract.xsd --noout schema_tests/tract/valid/*/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,11 @@ script:
   - bundle exec standardrb
   - bundle exec bundle audit check --update
   - bundle exec brakeman -A -q --no-pager --ensure-latest
+
+jobs:
+  include:
+  - name: "XML Schema Validation"
+    before_script: skip
+    script:
+    - xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/*.xml
+    - xmllint --schema public/xmlns/tract.xsd --noout schema_tests/tract/valid/*/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ jobs:
     - xmllint --schema public/xmlns/tract.xsd --noout schema_tests/tract/valid/*/*.xml
     # text invalid XML
     - ./schema_tests/invalid.sh public/xmlns/tract.xsd schema_tests/tract/invalid/*/*.xml
+    - ./schema_tests/invalid.sh public/xmlns/manifest.xsd schema_tests/manifest/invalid/*/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
     - bundle exec brakeman -A -q --no-pager --ensure-latest
 
   - name: "XML Schema Validation"
+    language: minimal
 
     addons:
       apt:

--- a/schema_tests/invalid.sh
+++ b/schema_tests/invalid.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+schema=$1; shift
+
+# shopt -s nullglob
+
+for f in $@
+do
+ if xmllint --schema $schema --noout $f; then
+ 	false
+ 	exit
+ fi
+done

--- a/schema_tests/invalid.sh
+++ b/schema_tests/invalid.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
 schema=$1; shift
-
-# shopt -s nullglob
-
 for f in $@
 do
  if xmllint --schema $schema --noout $f; then

--- a/schema_tests/manifest/invalid/tests/category_missing_label.xml
+++ b/schema_tests/manifest/invalid/tests/category_missing_label.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title>
+        <content:text i18n-id="name">Knowing God Personally</content:text>
+    </title>
+
+    <categories>
+        <category id="test" banner="test.jpg" />
+    </categories>
+</manifest>

--- a/schema_tests/manifest/valid/tests/categories.xml
+++ b/schema_tests/manifest/valid/tests/categories.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title>
+        <content:text i18n-id="name">Questions About God</content:text>
+    </title>
+
+    <categories>
+        <category id="about-god" banner="about-god.jpg">
+            <label>
+                <content:text>About God</content:text>
+            </label>
+            <article:aem-tag id="faith-topics:attributes-of-god/god-never-changes" />
+            <article:aem-tag id="faith-topics:share-your-faith/testimony" />
+        </category>
+    </categories>
+</manifest>

--- a/schema_tests/manifest/valid/tools/es.xml
+++ b/schema_tests/manifest/valid/tools/es.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <title>
+        <content:text i18n-id="name">Knowing God Personally</content:text>
+    </title>
+
+    <pages>
+        <article:aem-import src="https://stage.cru.org/content/experience-fragments/questions_about_god/english" />
+    </pages>
+</manifest>

--- a/schema_tests/manifest/valid/tools/kgp.xml
+++ b/schema_tests/manifest/valid/tools/kgp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    primary-color="rgba(59,164,219,1)"
+    primary-text-color="rgba(255,255,255,1)"
+    navbar-color="rgba(0,0,0,0)"
+    navbar-control-color="rgba(150,150,150,1)"
+    background-image="kgp-tract-bkg-image-0_1x.jpg">
+    <title>
+        <content:text i18n-id="name">Knowing God Personally</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tools/sat.xml
+++ b/schema_tests/manifest/valid/tools/sat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:tract="https://mobile-content-api.cru.org/xmlns/tract"
+    navbar-color="rgba(0,0,0,0.3)"
+    navbar-control-color="rgba(255,255,255,1)"
+    primary-color="rgba(59,164,219,1)"
+    primary-text-color="rgba(255,255,255,1)"
+    text-color="rgba(255,255,255,1)"
+    tract:card-background-color="rgba(255,255,255,1)">
+    <title>
+        <content:text i18n-id="name">Satisfied?</content:text>
+    </title>
+</manifest>

--- a/schema_tests/tract/invalid/tests/analyics_duplicate_attribute_keys.xml
+++ b/schema_tests/tract/invalid/tests/analyics_duplicate_attribute_keys.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <analytics:events>
+            <analytics:event system="adobe">
+                <analytics:attribute key="a" value="1" />
+                <analytics:attribute key="a" value="2" />
+            </analytics:event>
+        </analytics:events>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/kgp-us/1.xml
+++ b/schema_tests/tract/valid/kgp-us/1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-us-tract-bkg-image-1_1x.jpg">
+    <hero>
+        <heading>
+            <content:text i18n-id="a101126d-8dca-4af1-b352-d5357d111615" text-color="rgba(255,255,255,1)" text-scale="1.8">Would you like to Know God Personally?</content:text>
+        </heading>
+
+        <content:paragraph>
+            <content:text i18n-id="0cb1f173-c6bd-4ff4-aaf9-51cc762aac83">The following 4 principles will help you discover how to know God personally and experience the abundant life he promised.</content:text>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/kgp-us/10.xml
+++ b/schema_tests/tract/valid/kgp-us/10.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-color="rgba(200,200,200,1)">
+        <hero>
+        <content:paragraph>
+            <content:text i18n-id="de43404b-3d84-4700-877c-fb919c29a4e1" text-color="rgba(50,50,50,1)" text-align="center">Still not sure who Jesus is?</content:text>
+            <content:button type="url" url="https://www.everystudent.com/">
+                <content:text i18n-id="7993b15a-9210-406e-9280-fe78e9ce71b0">everystudent.com</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="a079eabc-c68f-49b7-96dc-6e5a3a197314" text-color="rgba(50,50,50,1)" text-align="center">More about Christianity</content:text>
+            <content:button type="url" url="http://www.startingwithgod.com/">
+                <content:text i18n-id="1044c1d5-ba87-4e07-bb15-630466514f7f">startingwithgod.com</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="da53a204-beba-4335-aca4-88285c91320e" text-color="rgba(50,50,50,1)" text-align="center">Read the Bible</content:text>
+            <content:button type="url" url="https://www.bible.com/bible/59/MRK.1">
+                <content:text i18n-id="adb3176c-5daf-49d5-83c9-97baac7f4b3d">bible.com/bible/59/mrk.1</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="5569d6a2-62b7-4ac9-a50e-c0af82fa196e" text-color="rgba(50,50,50,1)" text-align="center">Watch a film about Jesus</content:text>
+            <content:button type="url" url="https://www.jesusfilm.org/watch/jesus.html/english.html">
+                <content:text i18n-id="3d3aab07-172e-4f6e-ab9e-e3f6b9f18636">jesusfilm.org/watch/jesus.html/english.html</content:text>
+            </content:button>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/kgp-us/2.xml
+++ b/schema_tests/tract/valid/kgp-us/2.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-2_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<number>
+			<content:text>1</content:text>
+		</number>
+		<title>
+            <content:text i18n-id="af9b0880-e4df-4f85-8107-83e8165df25f">God loves you and created you to know Him personally. He offers a wonderful plan for your life.</content:text>
+        </title>
+	</header>
+	
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="a964de0e-b6f0-45fc-9c3a-bc1e67513d2e" text-color="rgba(177,95,90,1)">God’s love</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="b81f8cb9-8460-48d1-b4d3-a8d06e1f9294">“For God so loved the world, that He gave His only begotten Son, that whoever believes in Him shall not perish, but have eternal life.“ </content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="26c9c3af-c848-4862-b650-cfcf54e0e80f">John 3:16</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="5b8905b3-6ad2-4b96-855e-65fcb5d74bf3" text-color="rgba(177,95,90,1)">God’s plan</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="f1430c66-d61a-4947-b707-b24d5d7f6e1f">“Now this is eternal life: that they may know You, the only true God, and Jesus Christ, whom You have sent.“</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="c8d09801-9c58-499b-b382-924ea7c03777">John 17:3</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="9324bb4c-d285-4fcd-a624-9866eb11076b">What prevents us from knowing God personally?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/3.xml
+++ b/schema_tests/tract/valid/kgp-us/3.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-3_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<number>
+			<content:text>2</content:text>
+		</number>
+		<title>
+            <content:text i18n-id="d493cc97-8c2f-4fba-a4e8-1167c600d3a6">People are sinful and separated from God, so we cannot know Him personally or experience His love and plan.</content:text>
+        </title>
+	</header>
+	
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="3b40406d-07ac-4f6f-a215-514b77898bbe" text-color="rgba(177,95,90,1)">People are sinful</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="70880cae-345e-4495-bac4-7dc76dc97f8a">“…for all have sinned and fall short of the glory of God.”</content:text>
+                <content:text i18n-id="f637ff3a-3eb6-432e-a5d7-97d1e095fc85">Romans 3:23</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="eca97e91-2713-43a0-b075-bf7cca3e0551">People were created to have fellowship with God; but, because of our stubborn self-will, we chose to go our own independent way and fellowship with God was broken. This self-will, characterized by an attitude of active rebellion or passive indifference, is evidence of what the Bible calls sin.</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="6bf7c361-2c76-4284-a496-60b8aa4d622d" text-color="rgba(177,95,90,1)">People are separated</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7ed1499d-2f8c-45ef-b5e4-f63b592aa1f4">“For the wages of sin is death” [spiritual separation from God].</content:text>
+				<content:text i18n-id="e946f4c9-6fb2-4c03-9938-0c90435d6689">Romans 6:23</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:image resource="kgp-us-graphics-01.png" />
+                <content:text i18n-id="aa3c1337-b688-405e-8215-118943db6a37">This diagram illustrates that God is holy and people are sinful. A great gulf separates the two. The arrows illustrate that people are continually trying to reach God and establish a personal relationship with Him through their own efforts. Such as a good life, philosophy, or religion but we inevitably fail. </content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="d0df7f85-7cb7-47ea-acb6-ba3cc09c65ad">The third principle explains the only way to bridge this gulf…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/4.xml
+++ b/schema_tests/tract/valid/kgp-us/4.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-4_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<number>
+			<content:text>3</content:text>
+		</number>
+		<title>
+            <content:text i18n-id="708acabc-c443-4eea-8354-aef6cbfe9c01">Jesus Christ is God’s only provision for our sin. Through Him alone we can know God personally and experience God’s love and plan. </content:text>
+        </title>
+	</header>
+	
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="61d0955d-68b9-4f3d-9d51-dc6d6164b65e" text-color="rgba(177,95,90,1)">He died in our place</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="ff7100d3-b913-4034-957e-fe5a2b95eca0">“But God demonstrates His own love toward us, in that while we were yet sinners, Christ died for us.”</content:text>
+                <content:text i18n-id="b99bbe62-eed7-48b7-9ca7-da027dfc059a">Romans 5:8</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="9cb05469-f1ec-4c22-9a6a-5724f28ed474" text-color="rgba(177,95,90,1)">He rose from the dead</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="e6cb46d9-e6b1-40b8-b081-525feb9fdcdd">“…Christ died for our sins…He was buried, He was raised on the third day according to the Scriptures…He appeared to Peter, then to the twelve. After that, He appeared to more than five hundred…” </content:text>
+				<content:text i18n-id="002eee16-9631-4a33-8718-6b19c882e7ec">1 Corinthians 15:3-6</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="dda84f6e-a201-4eba-96d1-64db7c0f04e8" text-color="rgba(177,95,90,1)">He is the only way to God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="b0b72fec-5b24-48ab-bc8f-03c379a7c98b">“Jesus answered, ‘I am the way, and the truth, and the life; no one comes to the Father, but through Me.’”</content:text>
+				<content:text i18n-id="1c6e5568-d2db-4256-85ec-dabaa2bf0753">John 14:6</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:image resource="kgp-us-graphics-02.png" />
+                <content:text i18n-id="757f2d81-414f-4742-a336-88cb8899811c">This diagram illustrates that God has bridged the gulf that separates us from Him by sending His Son, Jesus Christ, to die on the cross in our place to pay the penalty for our sins.</content:text>
+			</content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="e46cb5f3-3a0b-4377-b51e-3b06ac83ffa8">It is not enough just to know these truths…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/5.xml
+++ b/schema_tests/tract/valid/kgp-us/5.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-5_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<number>
+			<content:text>4</content:text>
+		</number>
+		<title>
+            <content:text i18n-id="dbc57c0c-35c0-4af4-aeba-f1f4d9b331ac">We must individually receive Jesus Christ as Savior and Lord; then we can know God personally and experience His love and plan. </content:text>
+        </title>
+	</header>
+	
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="b884a50f-dccb-4e65-aa52-62ecb4024f43" text-color="rgba(177,95,90,1)">We must receive Jesus Christ</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="55dc4f51-aeb7-4da2-b768-162a7019e647">“Yet to all who received Him, to those who believed in His name, He gave the right to become children of God.”</content:text>
+                <content:text i18n-id="9066b687-ef7e-4c46-bdaa-a365620238a2">John 1:12</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="3f659af7-ed07-4a05-ba89-84d6f03ea9af" text-color="rgba(177,95,90,1)">We receive Christ through faith</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="c614f942-ecb6-4bcc-9e8a-9a0e9647dc2c">“For it is by grace you have been saved, through faith-and this not from yourselves, it is the gift of God-not by works, so that no one can boast.”</content:text>
+				<content:text i18n-id="1cd40bd8-401f-4966-953b-e5045c8df654">Ephensians 2:8-9</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="4f0b216e-917d-4902-a5c5-17d716ae7a68" text-color="rgba(177,95,90,1)">When we receive Christ…</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="9d7ba113-e3a0-4792-b9b1-1983532d9215">…we experience a new birth</content:text>
+            </content:paragraph>
+            <content:paragraph>
+				<content:text i18n-id="c0562644-8c6f-48d4-b455-b215cb0ab8a2">“Now there was a Pharisee, a man named Nicodemus who was a member of the Jewish ruling council.  He came to Jesus at night and said, ‘Rabbi, we know that you are a teacher who has come from God. For no one could perform the signs you are doing if God were not with him.’</content:text>
+			</content:paragraph>
+            <content:paragraph>
+				<content:text i18n-id="e35358f1-44a1-4300-849b-d18acf4de7af">Jesus replied, ‘Very truly I tell you, no one can see the kingdom of God unless they are born again.’</content:text>
+			</content:paragraph>
+            <content:paragraph>
+				<content:text i18n-id="41fc278e-3f46-4112-ad9c-630ae3930d58">‘How can someone be born when they are old?’ Nicodemus asked. ‘Surely they cannot enter a second time into their mother’s womb to be born!’</content:text>
+			</content:paragraph>
+            <content:paragraph>
+				<content:text i18n-id="9d8cad7f-4c59-4c9f-afc3-bfee8c0a1256">Jesus answered, ‘Very truly I tell you, no one can enter the kingdom of God unless they are born of water and the Spirit. Flesh gives birth to flesh, but the Spirit gives birth to spirit. You should not be surprised at my saying, ‘You must be born again.’ The wind blows wherever it pleases. You hear its sound, but you cannot tell where it comes from or where it is going. So it is with everyone born of the Spirit.’”</content:text>
+			</content:paragraph>
+            <content:paragraph>
+				<content:text i18n-id="30f47358-1d77-47a6-ba18-d44ca63137a3">John 3:1-8</content:text>
+			</content:paragraph>
+        </card>
+        
+        <card>
+            <label>
+                <content:text i18n-id="f041b1dc-647c-4543-8fc0-bd12b82ca80b" text-color="rgba(177,95,90,1)">We receive Christ by personal invitation</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="ec1a3ad3-fcb0-4961-8855-3b08def5bb2c">[Christ speaking] “Behold, I stand at the door and knock; if anyone hears My voice and opens the door, I will come in to him.” </content:text>
+				<content:text i18n-id="c6830879-e234-4c43-b30d-bf06c6064d9d">Revelation 3:20</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="b24e6400-7c28-4eb8-b16a-04f40c7c812e" text-color="rgba(177,95,90,1)">Two circles</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="d3328795-54a0-4168-8912-58a9b432cb52">“These two circles represent two kinds of lives:</content:text>
+                <content:tabs>
+                    <content:tab>
+                        <content:label>
+                            <content:text>1</content:text>
+                        </content:label>
+                        <content:image resource="kgp-us-graphics-03.png" />
+                        <content:text i18n-id="5ae5b7e5-e495-46d7-a8f6-a223b500fbd1">A life without Jesus Christ</content:text>
+						<content:text i18n-id="2581bf59-2b73-4ac3-9f9a-5303ec45c429">Self is in the center and on the throne. Christ is outside.</content:text>
+                	</content:tab>
+
+                    <content:tab>
+                        <content:label>
+                            <content:text>2</content:text>
+                        </content:label>
+                        <content:image resource="kgp-us-graphics-03.png" />
+                        <content:text i18n-id="ec22e521-66f1-4e3a-b995-77ea997a6d50">A life entrusted to Christ</content:text>
+                        <content:text i18n-id="a2d5e5cd-af9f-49bb-8a66-6dabe95acf1e">Christ is the center and on the throne, and self yields to Christ.</content:text>
+                	</content:tab>
+                </content:tabs>
+            </content:paragraph>
+
+            <content:paragraph>
+                <content:text i18n-id="96f988ad-5280-4dac-9500-2c541aa9a9e3">Which circle best represents your life?</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="56c9eb79-55c6-46af-8c0f-3e349fa83364">Which circle would you like to have represent your life?</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="75418495-61b5-4b34-904e-9656a96143bc">The following explains how you can receive Christ…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/6.xml
+++ b/schema_tests/tract/valid/kgp-us/6.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-us-tract-bkg-image-6_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+    <header>
+        <title>
+            <content:text i18n-id="28fa6f11-d870-4c12-a34f-63d706c90733">You can receive Christ right now by faith through prayer(prayer is talking with God).</content:text>
+        </title>
+    </header>
+
+    <hero>
+        <heading>
+            <content:text i18n-id="0d7fe262-9931-4040-bca8-c56c35ec7778" text-color="rgba(255,255,255,1)">God knows your heart and is not so concerned with your words as He is with the attitude of your heart. </content:text>
+        </heading>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="5bbda49f-4012-461b-8dc2-adeb34a1682c" text-color="rgba(177,95,90,1)">Here is a suggested prayer</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="fba8d7ae-4b27-4b57-9663-43416a7edd15">“Lord Jesus, I want to know you personally. Thank you for dying on the cross for my sins. I open the door of my life and receive You as my Savior and Lord. Thank you for forgiving my sins and giving me eternal life. Take control of the throne of my life. Make me the kind of person You want me to be.”</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="a89eb6c7-73d9-408e-a522-5c722e9d264a">Does this prayer express the desire of your heart?</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="bae55f58-0679-4101-9c30-298bb200f235">If it does, pray this prayer right now, and Christ will come into your life, as He promised. </content:text>
+            </content:paragraph>
+        </card>
+
+        <card dismiss-listeners="followup-form-no">
+            <label>
+                <content:text i18n-id="e1ba88d2-3eb7-4ded-a53b-663eee9d7094" text-color="rgba(177,95,90,1)">Did you pray this prayer?</content:text>
+            </label>
+            <content:paragraph>
+                <content:button type="event" events="followup-form-no">
+                    <content:text i18n-id="2045ce6b-4370-45b0-9eb8-68d544ad4fa2">Not Ready</content:text>
+                </content:button>
+                <content:button type="event" events="followup-form">
+                    <content:text i18n-id="228ff9c4-1670-4ee2-9bfd-c8bcb42f980e">Yes</content:text>
+                </content:button>
+                <content:link events="followup-form">
+                    <content:text i18n-id="fc6aadcc-fa18-4388-8549-240b666b081d">I already made this decision</content:text>
+                </content:link>
+            </content:paragraph>
+        </card>
+
+        <card hidden="true" listeners="followup-form">
+            <label>
+                <content:text i18n-id="52fe08b3-5c63-41a1-9f5a-db62ac126223">Jesus has come into your life as he promised.</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="04db5e56-d2a1-453b-9398-68250dd5081b">Knowing someone better helps a relationship grow. Would you like to sign up for an email series that can help guide you in your new relationship with Jesus Christ?</content:text>
+            </content:paragraph>
+            <content:form>
+                <content:input type="text" name="name">
+                    <content:label>
+                        <content:text i18n-id="99006111-eff5-4768-9ee7-fec51e784aa5">Name</content:text>
+                    </content:label>
+                    <content:placeholder>
+                        <content:text>First Name and Last Name</content:text>
+                    </content:placeholder>
+                </content:input>
+                <content:input type="email" name="email">
+                    <content:label>
+                        <content:text i18n-id="afa24d0e-2229-4ad3-9288-23f0b87b1a46">Email</content:text>
+                    </content:label>
+                    <content:placeholder>
+                        <content:text>Email</content:text>
+                    </content:placeholder>
+                </content:input>
+                <content:button type="event" events="followup:send send-information-modal">
+                    <content:text i18n-id="a1cbbc2e-00d1-4dd0-910b-ff431ff5b15d">Send</content:text>
+                </content:button>
+            </content:form>
+        </card>
+    </cards>
+    <modals>
+        <modal listeners="send-information-modal" dismiss-listeners="send-information-modal-close">
+            <title>
+                <content:text i18n-id="cc2b60d5-0ee8-4a0b-a015-7fba05fa2b36">Thank You </content:text>
+            </title>
+
+            <content:paragraph>
+                <content:text i18n-id="13d5c53b-5bc2-46b5-9227-89ec2d50e1df">Check your email soon for your first study in following Jesus Christ.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="61c530ea-8bf0-4711-bd6d-061f9f96b3ed">If you don’t receive it, please check your spam folder.
+                </content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:button type="event" events="send-information-modal-close">
+                    <content:text i18n-id="d8c86316-96ff-4d3b-a419-6a4b2e5ba52f">Done</content:text>
+                </content:button>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="605318fa-9b51-4dfd-b965-96b699e2cf31" text-scale="0.75">If this sign up occurs offline, you will need to reopen the app while on Wifi to have the signup automatically submit.</content:text>
+            </content:paragraph>
+        </modal>
+    </modals>
+
+    <call-to-action>
+        <content:text i18n-id="c8283dd9-c979-4e7b-9df9-a3f578485598">Christ will come into your life, as He promised.</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/7.xml
+++ b/schema_tests/tract/valid/kgp-us/7.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-7_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<title>
+            <content:text i18n-id="12a602a2-1227-4106-8a20-a2d9e850e473">How to know that Christ is in your life</content:text>
+        </title>
+	</header>
+			
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="bd09626a-ece6-4c38-9ef3-26fe3faee59f" text-color="rgba(177,95,90,1)">Did you receive Christ into your life?</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="33d5d13a-f570-4e19-9473-e7b5a45002de">According to His promise as recorded in Revelation 3:20, where is Christ right now in relation to you? Christ said that He would come into your life and be your Savior and friend so you can know Him personally. Would He mislead you? On what authority do you know that God has answered your prayer? (The trustworthiness of God Himself and His Word.)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="b04e0bc7-a023-465f-b531-faf4bf48b224" text-color="rgba(177,95,90,1)">The Bible promises Eternal Life to all who receive Christ</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="16737896-d758-43b7-8e9d-5bda44aadc4f">“And this is the testimony: God has given us eternal life, and this life is in His Son. He who has the Son has life; he who does not have the Son of God does not have life. I write these things to you who believe in the name of the Son of God so that you may know that you have eternal life.“</content:text>
+            	<content:text i18n-id="58048331-8316-44c9-b108-0bef8b5248ec">1 John 5:11-13</content:text>
+            </content:paragraph>
+            <content:paragraph>
+            	<content:text i18n-id="f6105b82-31c6-4d7a-a52e-e6060ade3b51">Thank God often that Christ is in your life and that He will never leave you (Hebrews 13:5). You can know on the basis of His promise that Christ lives in you and that you have eternal life from the very moment you invite Him in.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+            	<content:text i18n-id="ba966665-1c3a-4b4c-b37d-8685dbcb3d31">An important reminder…</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="ec49bd3b-c6bc-418a-a03f-aab57110b679" text-color="rgba(177,95,90,1)">Do not depend on feelings</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="b07dd23d-056d-4e41-81d0-9245d57e863e">The promise of God’s Word, the Bible-not our feelings-is our authority. The Christian lives by faith (trust) in the trustworthiness of God Himself and His Word. This train diagram illustrates the relationship between fact (God and His Word), faith (our trust in God and His Word), and feeling (the result of our faith and obedience)</content:text>
+            	<content:text i18n-id="8cf79bed-30b2-4dbb-a0e4-f5c0800914c9">John 14:21</content:text>
+            </content:paragraph>
+            <content:paragraph>
+            	<content:text i18n-id="f27505f4-ad57-40cd-a570-0246f36589cd">The train will run with or without the caboose. However, it would be useless to attempt to pull the train by the caboose. In the same way, we, as Christians, do not depend on feelings or emotions, but we place our faith (trust) in the trustworthiness of God and the promise of His Word. </content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+</page>

--- a/schema_tests/tract/valid/kgp-us/8.xml
+++ b/schema_tests/tract/valid/kgp-us/8.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-8_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<title>
+            <content:text i18n-id="3d7f3a12-995d-46b7-a235-30a4e9ab9054">Now that you have entered into a personal relationship with Christ
+The moment that you received Christ by faith, as an act of the will, many things happened, including the following:</content:text>
+        </title>
+	</header>
+			
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="97d0521b-cdfa-4fed-a282-8243aadff789" text-color="rgba(177,95,90,1)">Christ came into your life</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="ce041037-7813-4e3c-8265-1ec433cc6dc3">[Christ speaking] “Behold, I stand at the door and knock; if anyone hears My voice and opens the door, I will come in to him.”</content:text>
+                <content:text i18n-id="c1a4acba-5608-4e1b-9be7-dea96b90f03e">Revelation 3:20</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="8888c018-12e7-40ee-b05d-95ab6a1e6019">“To them God has chosen to make known among the Gentiles the glorious riches of this mystery, which is Christ in you, the hope of glory.”</content:text>
+                <content:text i18n-id="de94f9be-b398-47fd-b866-0df4a5fac183">Colossians 1:27</content:text>
+            </content:paragraph>
+        </card>
+        
+        <card>
+            <label>
+                <content:text i18n-id="da79a14e-ed43-4edf-b1bb-29c40e2bef97" text-color="rgba(177,95,90,1)">Your sins were forgiven</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="26c8380c-7733-4683-a7e5-0f8f7e952396">“For he has rescued us from the dominion of darkness and brought us into the kingdom of the Son he loves, 14 in whom we have redemption, the forgiveness of sins.”</content:text>
+            	<content:text i18n-id="6beb7d92-fb8b-4ed8-bbec-5a815345492c">Colossians 1:13-14</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="aa55729f-bca3-4603-9e98-0322c75df7b6" text-color="rgba(177,95,90,1)">You became a child of God</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="22d144eb-407e-4202-aeed-a2f9770851e1">“Yet to all who did receive him, to those who believed in his name, he gave the right to become children of God.”</content:text>
+            	<content:text i18n-id="550941b6-593f-4960-8932-911905d6d904">John 1:12</content:text>
+            </content:paragraph>
+        </card>
+        
+        <card>
+            <label>
+                <content:text i18n-id="04414217-3dbe-4088-9d03-c5e82200f1e3" text-color="rgba(177,95,90,1)">You received eternal life</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="1aaef763-7560-42ff-af6f-0756fca432e7">“Very truly I tell you, whoever hears my word and believes him who sent me has eternal life and will not be judged but has crossed over from death to life.”</content:text>
+            	<content:text i18n-id="ece5f0d6-b70b-44e2-9da8-b430d36994a9">John 5:24</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="a48c9ccf-461f-436a-88db-bfd42372f0cd" text-color="rgba(177,95,90,1)">You began the great adventure…</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="0b6ed4e0-e9d5-4a44-a112-d4c4392c3041">for which God created you.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+            	<content:text i18n-id="41bb8732-ef18-43bd-a131-fb38f5f376cf">“I have come that they may have life, and have it to the full.” John 10:10</content:text>
+            	<content:text i18n-id="a0dc08d6-ef72-4ff0-a763-8eeba82dfd09"> 2 Corinthians 5:17; 1 Thessalonians 5:18</content:text>
+            </content:paragraph>
+            <content:paragraph>
+            	<content:text i18n-id="d83e1db5-e5e0-477b-a2cd-42383e13fb01">Can you think of anything more wonderful that could happen to you than entering into a personal relationship with Jesus Christ? Would you like to thank God in prayer right now for what He has done for you? By thanking God, you demonstrate your faith.</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    
+    <call-to-action>
+    	<content:text i18n-id="aecad30a-0f56-4408-b293-6d891fc92048">To enjoy your new relationship with God…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp-us/9.xml
+++ b/schema_tests/tract/valid/kgp-us/9.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" 
+    background-image="kgp-us-tract-bkg-image-9_1x.jpg"
+    card-text-color="rgba(50,50,50,1)">
+
+	<header>
+		<title>
+            <content:text i18n-id="7729cd15-f59e-40ba-a849-297ac093438d">Suggestions for Christian Growth</content:text>
+        </title>
+	</header>
+			
+	<hero>
+		<heading>
+			<content:text i18n-id="56ae549a-787a-4a4f-bbb5-8618fb8ad695" text-color="rgba(255,255,255,1)" text-scale="0.75">Spiritual growth results from trusting Jesus Christ. “…The righteous will live by faith” (Galatians 3:11). A life of faith will enable you to trust God increasingly with every detail of your life, and to practice the following:</content:text>
+		</heading>
+	</hero>
+	
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="233df032-5e9f-432d-a4a9-743bf1ae6316" text-color="rgba(177,95,90,1)">Go</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="ecc48413-ba3d-4f45-93b1-e3d71b975f76">Go to God in prayer daily.</content:text>
+                <content:text i18n-id="fd3eb6ab-c6c6-464a-b608-bd9fff4d975e">John 15:7</content:text>
+            </content:paragraph>
+        </card>
+        
+        <card>
+            <label>
+                <content:text i18n-id="5eb9c2d8-6cf1-4815-bfe3-92e289fed508" text-color="rgba(177,95,90,1)">Read</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="9545abc5-af86-486d-9ec2-70427f1eebb1">Read God's Word daily.</content:text>
+            	<content:text i18n-id="e59d818f-a155-4dfd-b437-d3006795693b">Acts 17:11</content:text>
+            	<content:text i18n-id="7901cd8a-9253-43da-b8ed-6ab63b432917">Begin with the Gospel of John or Mark.</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="794ce3eb-3482-4fe5-8635-9dfd6b8261ec" text-color="rgba(177,95,90,1)">Obey</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="ddcf3c20-956b-44cb-ada4-3de9c22ea8a7">Obey God moment by moment.</content:text>
+            	<content:text i18n-id="a1f1dbaf-b534-4a8d-ba22-eda2e7910e64">John 14:21</content:text>
+            </content:paragraph>
+        </card>
+        
+        <card>
+            <label>
+                <content:text i18n-id="81944811-8769-463e-bd26-9fddae3a1d9e" text-color="rgba(177,95,90,1)">Witness</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="df33e560-db64-4872-897e-310a64a31a98">Witness for Christ by your life and words.</content:text>
+            	<content:text i18n-id="ba0dae1f-97d2-4f78-9c40-b95f01a1a123">Matthew 4:19; John 15:8</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="501f41f8-729b-488f-9856-f90334c92d26" text-color="rgba(177,95,90,1)">Trust</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="5b03f1a9-6d45-4ab2-8359-292b9c09037f">Trust God for every detail of your life.</content:text>
+            	<content:text i18n-id="1e2a65a9-5cda-4e5a-a371-3e7ee27bcbe9">1 Peter 5:7</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="5a6f73d0-adf1-4e34-aa61-f0915d03d36b" text-color="rgba(177,95,90,1)">Holy Spirit</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="5900ae41-fa89-4228-aa41-39e453ee528d">Allow Him to control and empower your daily life and witness. Your walk with Christ depends on what you allow Him to do in and through you empowered by the Holy Spirit, not what you do for Him through self effort. </content:text>
+            	<content:text i18n-id="cdaa1760-8f1a-4ca5-a883-06652ca0c8e2">Galatians 5:16-17; Acts 1:8</content:text>
+            </content:paragraph>
+        </card>
+        
+		<card>
+            <label>
+                <content:text i18n-id="2f41ed24-fb83-4f97-a6b6-e30ade95b65c" text-color="rgba(177,95,90,1)">Fellowship in a good church</content:text>
+            </label>
+            <content:paragraph>
+            	<content:text i18n-id="4f763555-efe6-447c-be4a-16d930878a92">God’s word admonishes us, “Let us not give up meeting together…” (Hebrews 10:25). Several logs burn brightly together; but put one aside on the cold hearth and the fire goes out. So it is with your relationship with other Christians. If you do not belong to a church, do not wait to be invited. Take the initiative; call the pastor of a nearby church where Christ is honored and His Word is preached. Start this week, and make plans to attend regularly.</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    
+    <call-to-action>
+    	<content:text i18n-id="53dc44f2-5c65-45c5-ba40-bca22beaad8d">Want to know more?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/01_Home.xml
+++ b/schema_tests/tract/valid/kgp/01_Home.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-0_1x.jpg"
+    background-image-align="bottom">
+    <hero>
+        <heading>
+            <content:text i18n-id="45e65db9-957f-4ca5-b4ca-b60c4ce424c1">Knowing God Personally</content:text>
+        </heading>
+
+        <content:paragraph>
+            <content:text i18n-id="778006c5-22a7-4abb-b81e-f04499f942e6">These four points explain how to enter into a personal relationship with God and experience the life for which you were created.</content:text>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/kgp/02_FirstPoint.xml
+++ b/schema_tests/tract/valid/kgp/02_FirstPoint.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-1_1x.jpg">
+    <header>
+        <number>
+            <content:text>1</content:text>
+        </number>
+        <title>
+            <content:text i18n-id="087b7293-70aa-41c7-b6cc-5d397a4eb41b">God loves you and created you to know him personally.</content:text>
+        </title>
+    </header>
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="2c1f7198-f0a1-40cb-b71f-b50237866f15">God loves you</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="8189a000-f7d3-4bc3-8eea-ef826c53dc5c">"God showed how much he loved us by sending his one and only Son into the world so that we might have eternal life through him."</content:text>
+                <content:text i18n-id="4919a9b7-f874-4362-87d5-c59ec8da754c">- 1 John 4:9</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="f0ab9318-ed38-426d-946d-0668adb55f02">God wants you to know him</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="90c1f8d1-39c0-49f8-b905-5bd7e850eef8">“Now this is eternal life: that they may know You, the only true God, and Jesus Christ, whom You have sent.”</content:text>
+                <content:text i18n-id="df32c4e8-e832-4026-870e-cbde62215c5b">John 17:3 NIV</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="fae69b3b-e95b-4184-9bcd-211e35faa71c">Why do you think most people don’t know God personally?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/03_SecondPoint.xml
+++ b/schema_tests/tract/valid/kgp/03_SecondPoint.xml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-2_1x.jpg">
+    <header>
+        <number>
+            <content:text>2</content:text>
+        </number>
+        <title>
+            <content:text i18n-id="4b0da95a-13fa-44ce-8540-ed951dda6979">We are separated from God by our sin, so we cannot know him or experience his love.</content:text>
+        </title>
+    </header>
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="417a1866-7865-48b6-8144-9f5318e9d60d">What is sin?</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7743b4d5-3f48-4c69-8062-3e2216cc66a6">We were created to have a relationship with God, but we rejected him and the relationship was broken.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="f3a5855f-56cc-4af4-8220-eef262aac39c">This rejection of God and the building of our lives around anything else is what the Bible calls sin.</content:text>
+            </content:paragraph>
+        </card>
+        <card background-image="kgp-page-bkg-image-people_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="81787028-e394-404e-a6ee-fd58caf571f6">Everyone is sinful</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="03346729-5937-4bee-8f49-3511e473ffa0">“For everyone has sinned: we all fall short of God’s glorious standard.”</content:text>
+                <content:text i18n-id="b59b8b23-53cd-4097-86e4-819c619abde2">Romans 3:23</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="19d02696-6124-4a1e-9183-15156f3c9bbb">Sin has consequences</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7f82556a-3890-487c-8c37-e498cb254285">For the wages of sin is death, but the free gift of God is eternal life through Christ Jesus our Lord. Romans 6:23</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="28acdb15-948c-4cc1-a619-4dfc088ace38">God is perfect and just and will hold us accountable for our sin. There is a penalty for rejecting God.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="18b0b51d-37c6-498c-9dad-7556168b87f0">God is perfect and we are sinful. There is a great gap between us because of our sin.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="8101324b-ef7f-4f3e-a2d5-21c52efc48a5">We may try to bridge this gap through good deeds or following a religion. However, all our efforts fail because they can’t solve the problem of sin that keeps us from God.</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="69451881-ebca-4317-8a53-38f40aa8197d">The third point gives us the only solution to this problem…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/04_ThirdPoint.xml
+++ b/schema_tests/tract/valid/kgp/04_ThirdPoint.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-3_1x.jpg">
+    <header>
+        <number>
+            <content:text>3</content:text>
+        </number>
+        <title>
+            <content:text i18n-id="5a5ae378-915a-4fff-99af-9f0e6a91a86d">Jesus is God's only solution for our sin. Only through him can we know God and receive his love and forgiveness.</content:text>
+        </title>
+    </header>
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="cdfb46b6-6827-406d-b908-7b12566d4475">Jesus is God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="f70b16f3-6f64-41eb-855c-3144817079ef">Christ is the visible image of the invisible God. He existed before anything was created and is supreme over all creation.</content:text>
+                <content:text i18n-id="e14d6b3b-f1b0-4487-8dd8-ec26eb6c32c3">Colossians 1:15</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="709eefb9-dfaf-48d8-8265-beaf10a7677a">Jesus died in our place</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="e9cacbb8-f5ed-41b7-a088-352484fb3a6a">Christ suffered for our sins once for all time. He never sinned, but he died for sinners to bring you home safely to God.</content:text>
+                <content:text i18n-id="0f0d51c7-d642-4b1d-98c0-1e6ce643180b">1 Peter 3:18a</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="fc311c3c-cccd-4376-ba75-a5829a9b339f">Jesus came back to life</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="8accddf2-2b51-4e70-9442-d8370a95914f">During the forty days after his crucifixion, he appeared to the apostles … and he proved to them in many ways he was actually alive. Acts 1:3a</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="d94a834a-bb44-4eaf-a32f-6825d403937f">His resurrection proved that he was God and that he had suffered the punishment we deserved in our place.</content:text>
+            </content:paragraph>
+        </card>
+        <card background-image= "kgp-page-bkg-image-hands_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="5db3b981-35ba-4a56-902a-a366d4ce1930">Jesus is the only way...</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="bd8f809c-9bff-4a44-8935-d511ce68cbfc">Jesus said, "I am the way, the truth and the life. No-one can come to the Father except through me."</content:text>
+                <content:text i18n-id="6716296c-4d2d-47e1-b6b4-3670f06e47ff">John 14:6</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="6751fa1d-efb6-431a-9907-1ce355ae50e4">God proves his love...</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="ae5d8b0a-4cbe-4749-982c-e014ad4f652b">For God loved the world so much that he gave his one and only Son, so that everyone who believes in him will not perish but have eternal life. John 3:16</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="c5e6b703-6978-4111-af16-3517e874da81">Although we deserve to be cut off from God forever, in his love God sent Jesus to pay the penalty for our sins by dying on the cross.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="0c2d3c8d-351d-4167-ada4-3feb9ce0425c">Through Jesus, God has bridged the gap that separates us from him, and provided a way for us to be forgiven and restored to relationship with him.</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="3adb3d8b-dd79-4448-a0b4-9816972866dd">It’s not enough just to know these points…</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/05_FourthPoint.xml
+++ b/schema_tests/tract/valid/kgp/05_FourthPoint.xml
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-4_1x.jpg">
+    <header>
+        <number>
+            <content:text>4</content:text>
+        </number>
+        <title>
+            <content:text i18n-id="1bad3039-8523-4959-9d08-846ea749873a">We must each respond to Jesus by placing our trust in him as our Savior and Lord. Only then can we know God personally.</content:text>
+        </title>
+    </header>
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="f2bb59eb-4921-4157-9ae4-27422cd88727">This response involves...</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="28a68eff-6a53-43bd-8464-bb217c41a8ad">Agreeing</content:text>
+                <content:text i18n-id="cf1d7e3e-02b7-4a0b-a1a2-96ecbad4e24d">with God that we are sinful and deciding to run from our sin.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="35525f3b-5fa8-405e-a67e-b67fc8eb95b3">Trusting</content:text>
+                <content:text i18n-id="a4f50f2c-6d0d-4071-a3ef-521e86b28809">God to forgive us completely because Jesus died for our sin.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="7c973705-08f5-4521-8098-77abb07c2cf4">Choosing</content:text>
+                <content:text i18n-id="1d10c00d-7f6c-47a4-9083-0f4bcfd4790c">to follow Jesus; putting him first in our lives.</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="286938f8-e627-4440-8c2e-f3f6d8f2bfa1">The relationship is personal</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="c252e95d-6815-4ee2-9d3b-34497691bdbe">"But to all who believed in him and accepted him, he gave the right to become children of God".</content:text>
+                <content:text i18n-id="82564a55-938c-4d32-8209-dbcb5bdf04e9">John 1:12</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="caab9e72-d960-4a34-9a57-750d1c77a69a">The relationship is a gift</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="1ff0a490-5b3d-45b4-bd7e-635c6d89b08a">God saved you by his grace when you believed. And you can’t take credit for this; it’s a gift from God … so none of us can boast about it.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="ec410cc4-4eb3-441a-bd67-ad617cd805c6">He saved us, not because of the righteous things we had done, but because of his mercy. He washed away our sins, giving us a new birth and new life.</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="f79ea491-2487-4fbf-89bc-8d26d10e021d">We have a choice to make</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="c6b7930d-4ce0-4b4c-b2d7-b6d796d91c25">These circles describe two types of people.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:tabs>
+                    <content:tab>
+                        <content:label>
+                            <content:text>1</content:text>
+                        </content:label>
+                        <content:image resource="kgp-image-self-directed.png" />
+                        <content:text i18n-id="12ed0c77-60e4-4a5e-9383-9224022bb256">People like this have never received Jesus into their lives. They remain guilty and cut off from God by their sins.</content:text>
+                    </content:tab>
+                    <content:tab>
+                        <content:label>
+                            <content:text>2</content:text>
+                        </content:label>
+                        <content:image resource="kgp-image-christ-directed.png" />
+                        <content:text i18n-id="bb67b904-4207-45d9-9473-d2e1d5a9abf4">People like this have received Jesus into their lives. They have been forgiven an experience God’s love.</content:text>
+                    </content:tab>
+                </content:tabs>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="c1c29312-4a3c-4adb-84b1-a14d1507ca07">Which circle best describes you? Which would you like to describe you?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/07_AttitudeOfYourHeart.xml
+++ b/schema_tests/tract/valid/kgp/07_AttitudeOfYourHeart.xml
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-5_1x.jpg">
+    <header>
+        <title>
+            <content:text i18n-id="c0beaeda-451e-453c-ae46-8524ff73c711">To begin a relationship with God, you must place your trust in Jesus alone.</content:text>
+        </title>
+    </header>
+
+    <hero>
+        <content:paragraph>
+            <content:text i18n-id="37d91324-47f6-46a6-9311-6a569be27661">GOD IS NOT SO CONCERNED WITH YOUR WORDS AS HE IS WITH THE ATTITUDE OF YOUR HEART.</content:text>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="09e36daa-998f-4ff7-a931-40d210d3c77e">YOU CAN EXPRESS YOUR ATTITUDE TOWARDS GOD THROUGH PRAYER.</content:text>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="5bcdf851-6ba4-452f-b5f8-3ed38758ce61">Prayer is simply talking with God.</content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="bbdb4438-4c50-430c-bd47-084bf77294be">Here is a suggested prayer</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="88a13a09-c5f6-4dd0-9fb3-88119738cf3c">Lord Jesus,</content:text>
+                <content:text i18n-id="453de523-1828-404b-be29-898ebc0bf8d5">I want to know you personally. </content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="f83226fc-3e6d-476e-a1fd-8b411b1cdcb3">I’m sorry for going my own way. Please forgive me for all my sin.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="8020a609-0984-43a7-81a8-be46cd573cc1">Thank you for dying on the cross to pay for my sin.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="74fa69ef-1a88-4fee-af2a-1b6884e6677c">I agree to turn from my old ways and follow you as my Savior and Lord. Please come and take first place in my life.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:image resource="kgp-page-image-card-divider_1x.png" />
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="51d896fa-67f7-42e1-aa4d-e0122d46a658">Could you say this to God and mean it?</content:text>
+                <content:text i18n-id="fdbc4e08-8d4f-4ff5-a6c2-f37b765f5351">Is there anything stopping you from saying this right now?</content:text>
+            </content:paragraph>
+        </card>
+        <card dismiss-listeners="followup-form-no">
+            <label>
+                <content:text i18n-id="d9dc4a05-7900-430a-8eaf-ee2d3bdad80e">Did you pray this prayer?</content:text>
+            </label>
+            <content:paragraph>
+                <content:button type="event" events="followup-form-no">
+                    <content:text i18n-id="a1e39205-8092-4aed-91e8-501574819a9b">Not Ready</content:text>
+                </content:button>
+                <content:button type="event" events="followup-form">
+                    <content:text i18n-id="379c1bf4-f5e7-45df-85a4-dfc95dad22ca">Yes</content:text>
+                </content:button>
+            </content:paragraph>
+            <content:paragraph>
+                <content:link events="followup-form">
+                    <content:text i18n-id="c696dbf4-f3d4-43ef-a3ed-59ae8921c3fd" text-align="center">I already made this decision</content:text>
+                    <analytics:events>
+                        <analytics:event system="adobe">
+                            <analytics:attribute key="test"/>
+                        </analytics:event>
+                    </analytics:events>
+                </content:link>
+            </content:paragraph>
+        </card>
+        <card hidden="true" listeners="followup-form">
+            <label>
+                <content:text i18n-id="035c27d5-97a3-48c9-aa10-a969ec12174e">Jesus has come into your life as he promised.</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="6b1edf38-25d1-431d-b636-e35f122901dc">Knowing someone better helps a relationship grow. Would you like to sign up for an email series that can help guide you in your new relationship with Jesus Christ?</content:text>
+            </content:paragraph>
+            <content:form>
+                <content:input name="destination_id" type="hidden" value="1" />
+                <content:input type="text" name="name" required="true">
+                    <content:label>
+                        <content:text i18n-id="cb98c9b5-a77f-466c-bee4-57f6289a3b4b">Name</content:text>
+                    </content:label>
+                    <content:placeholder>
+                        <content:text>First Name and Last Name</content:text>
+                    </content:placeholder>
+                </content:input>
+                <content:input type="email" name="email" required="true">
+                    <content:label>
+                        <content:text i18n-id="f5c6c928-edec-4a99-8542-476e1b9da8d5">Email</content:text>
+                    </content:label>
+                    <content:placeholder>
+                        <content:text>Email</content:text>
+                    </content:placeholder>
+                </content:input>
+                <content:button type="event" events="followup:send send-information-modal">
+                    <content:text i18n-id="f9a7f467-0f5b-49c9-aa94-6a51b6119e4c">Send</content:text>
+                </content:button>
+            </content:form>
+        </card>
+    </cards>
+    <modals>
+        <modal listeners="send-information-modal" dismiss-listeners="send-information-modal-close">
+            <title>
+                <content:text i18n-id="42e142ff-f5b2-4348-9125-c37a95535b36">Thank You </content:text>
+            </title>
+
+            <content:paragraph>
+                <content:text i18n-id="459e3b81-7020-4dda-ae37-9a1b721b7d97">Check your email soon for your first study in following Jesus Christ.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="60e5c620-d418-427a-9731-e14f0cd07656">If you don’t receive it, please check your spam folder.
+                </content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:button type="event" events="send-information-modal-close information-form-card-close">
+                    <content:text i18n-id="8975d598-6578-41c8-8d26-b4bdd2a0dd2a">Done</content:text>
+                </content:button>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="43e52076-d4c6-4fa1-ab4f-3896dbe1ef50" text-scale="0.75">If this sign up occurs offline, you will need to reopen the app while on Wifi to have the signup automatically submit.</content:text>
+            </content:paragraph>
+        </modal>
+    </modals>
+</page>

--- a/schema_tests/tract/valid/kgp/09_WhatHappens.xml
+++ b/schema_tests/tract/valid/kgp/09_WhatHappens.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-6_1x.jpg"
+    background-image-scale-type="fill">
+    <header>
+        <title>
+            <content:text i18n-id="2fdca489-1406-419c-b35b-5ade1afa9f7b">What Happens When You Put Your Trust In Jesus?</content:text>
+        </title>
+    </header>
+
+    <hero>
+        <content:paragraph>
+            <content:text i18n-id="d9b98feb-50ca-4a60-ae9e-435c3849c276">IF YOU ASKED JESUS INTO YOUR LIFE AS SAVIOUR AND LORD, MANY THINGS HAVE HAPPENED, INCLUDING:</content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="a2e2e777-39f0-4e59-a427-bcae73a93ef5">Jesus Has Come Into Your Life</content:text>
+            </label>
+
+            <content:paragraph>
+                <content:text i18n-id="5302c48f-e424-4a87-8f1b-5ce617a8aa8c">Jesus has come into your life by the Holy Spirit and he will never leave you.</content:text>
+                <content:text i18n-id="04fb1daf-6990-4153-9f60-7cf793a1e79b">(Hebrews 13:5)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="d4a4a53d-d84e-4463-8394-1ed0c3b60095">All your sins have been forgiven.</content:text>
+            </label>
+
+            <content:paragraph>
+                <content:text i18n-id="8ae60223-9586-4dca-96ee-1c3c01614eef">All your sins have been forgiven.</content:text>
+                <content:text i18n-id="f9e251ac-2de8-4e31-a7eb-e6e656b129e0">(Colossians 1:13-14)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="d754b66e-f4e6-4bd4-9764-af8b50e0f531">You Are Now a Child of God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="9cb35a1d-04fb-4172-9752-63a8f52012b0">You have become a child of God. He is your heavenly father.</content:text>
+                <content:text i18n-id="fae8031d-d8fe-498e-9d2f-c8c3147bc26a">(Galatians 3:26)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="fa829ea2-0ce4-4a97-8b26-79bfbb93733e">You Have Been Empowered</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="b61c767f-ef3c-4a5a-bdfb-3d660dea67ff">God has given you new power to live a transformed life.</content:text>
+                <content:text i18n-id="890268cf-4d0f-4b0c-ae62-8efb54f724b2">(2 Corinthians 5:17; Ephesians 3:14-21)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="02ae9b80-acdf-4f58-af8a-a33ad348bf4e">You Are Now Friends with God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7acd2e78-76ab-4b26-a286-51466da85107">You have started a friendship with God that will last forever.</content:text>
+                <content:text i18n-id="a63a4ef6-d990-4ca7-9f68-e22e168d1cf7">(John 17:3)</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="fcea282c-75f3-4fbc-b1cd-e7e229390ec3">But how do we know this actually happened?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/11_HowCanYouBeSure.xml
+++ b/schema_tests/tract/valid/kgp/11_HowCanYouBeSure.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    background-image="kgp-tract-bkg-image-7_1x.jpg">
+    <header>
+        <title>
+            <content:text i18n-id="0fd9adaf-cdba-45c5-81c4-5f7efa20e218">HOW CAN YOU BE SURE THAT ALL THIS HAS REALLY HAPPENED?</content:text>
+        </title>
+    </header>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="fb9cc164-e14a-4a58-b6ec-f34d2b38e4ae">Jesus Is in Your Life ...</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="f0a21cfe-ceef-456b-963e-73301e0326ad">...because God has promised, and he can be trusted.</content:text>
+                <content:text i18n-id="caaac9b4-8c0a-41c8-b1d8-ebcf5f3d396a">Thank God often that Jesus is in your life, and that he will never leave you.</content:text>
+                <content:text i18n-id="8dc10789-3ce1-40cb-83cc-fb9f6995add2">(Romans 8:38-39)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="86baf970-534c-4572-9ec4-6bae9576c180">You Have the Spirit of Christ</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="a860d2ef-d295-4ed4-bb61-fa5e27464005">You can know that the Spirit of Christ lives in you and that you have eternal life from the moment you invited Jesus into your life, because this is what he has promised.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="84cda5a7-6250-43a2-809b-c2ed0e95ac67">"And this is what God has testified: He has given us eternal life, and this life is in his Son. Whoever has the Son has life; whoever does not have God's Son does not have life. I have written this to you who believe in the name of the Son of God, so that you may know you have eternal life."</content:text>
+                <content:text i18n-id="896a2688-4c05-46e7-b253-a2b41d644ce2">-1 John 5:11-13</content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="aa82966a-a0a5-4c38-8693-6cc2f361fb50">Rely on God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="4afffabe-3392-46e1-a545-145a799f6e9c">Although feelings are valid and important, they don't determine what is true. A follower of Jesus lives by trusting in the reliability of God himself and what he has said.</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-plane_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="47379433-1c4d-4abc-bf96-120c52e24574">Trust Facts Not Feelings</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="668f5455-9d31-419e-a2a7-59ba58fe9dc3">To be transported by an airplane, we must put our trust in the construction of the aircraft. Our feelings do not influence the fact that the plane will carry us.</content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="1a37d575-79eb-4c28-9aaa-b1d7a10dcb4d">In the same way, we can rely on God and trust what he has promised in the Bible, and not depend on the way we feel.</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="64636042-ccea-427f-93fe-288651b576f6">So what comes next?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/12_HowToGrow.xml
+++ b/schema_tests/tract/valid/kgp/12_HowToGrow.xml
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-8_1x.jpg"
+    background-image-align="top"
+    background-image-scale-type="fill">
+    <header>
+        <title>
+            <content:text i18n-id="ef36067a-1620-407c-8ac5-0bc0175e2110">HOW TO GROW AS A FOLLOWER OF JESUS:</content:text>
+        </title>
+    </header>
+
+    <cards>
+        <card background-image="kgp-page-bkg-image-growth-1_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="44d1491b-8c6e-4317-b706-181ac178a684">Get to Know God</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="680c943f-1c90-4704-9462-ba9aa66b2459">Get to know God by reading the Bible daily. (2 Timothy 3:14-17)</content:text>
+                <content:text i18n-id="455ca736-9082-4b2a-a6c8-ed018b748edb">Begin with the gospel of John or Mark.</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-growth-2_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="9dfc03e6-1903-4681-9026-7f3f459f49d8">Respond</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="933151b5-b6d8-4ba8-afa7-e1466bc3ad99">Respond to God in prayer.</content:text>
+                <content:text i18n-id="b32d7c22-52c2-475e-974c-3fdbfe31c220">(Phillipians 4:6)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-growth-3_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="69cf56c1-c44e-47e5-9925-4bbae443738a">Obey</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="f8d16954-f28b-49e1-9332-3a8ecc34fa2b">Obey God Moment by Moment</content:text>
+                <content:text i18n-id="4fe11c37-1417-492c-9ad6-93ed9c4b5e8f">(Luke 6:46-49)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-growth-4_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="b0b3655d-17cf-4062-acec-55bdd22f4c05">Walk</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="5d5bfae0-2d08-41fc-98c9-0342a1e24a71">Walk in the Power of the Holy Spirit.</content:text>
+                <content:text i18n-id="d5aa2a8a-1d2a-444d-a5e5-2b84822cceb1">(Ephesians 3:14-21, 5:18)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-growth-5_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="f5b41b17-cf97-4494-be03-ef3421aec8b5">Tell Others</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="3e6334e9-b558-4950-ba6f-2411a227e1b3">Tell others about Jesus through your life and words.</content:text>
+                <content:text i18n-id="edd20029-947e-41e5-9220-d76acf73f50b">(Matthew 28:18-20; 2 Corinthians 5:17-20; Ephesians 4:1)</content:text>
+            </content:paragraph>
+        </card>
+
+        <card background-image="kgp-page-bkg-image-growth-6_1x.jpg" background-image-align="bottom">
+            <label>
+                <content:text i18n-id="c8b50534-6b4b-46f5-8232-9fb429ad99ce">Have Fellowship</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="e11332aa-e67c-4917-9e86-718c3c3bd629">Have fellowship with other Christians</content:text>
+                <content:text i18n-id="93784cbf-6e2e-479c-8e58-915c7c04fbf1">(Hebrews 10:25; Acts 2:42-47)</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="16c35b12-5a40-48ed-80dd-dd3066fdb735">Want to know more?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/kgp/13_FinalPage.xml
+++ b/schema_tests/tract/valid/kgp/13_FinalPage.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:text i18n-id="2b883c27-3cf3-4046-a075-f5ddd97c881e" text-align="center">Still not sure who Jesus is?</content:text>
+            <content:button type="url" url="https://www.everystudent.com/">
+                <content:text i18n-id="3285f0ab-f247-4524-bcc1-b757d2db85a9">everystudent.com</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="22ddc59d-91cc-4432-90a9-1730d995f7d3" text-align="center">More about Christianity...</content:text>
+            <content:button type="url" url="http://www.startingwithgod.com/">
+                <content:text i18n-id="f1225cff-2834-486a-a93e-b8dd4efd7a5c">startingwithgod.com</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="1065a75a-70fa-469e-a978-0d2a93d9c0d2" text-align="center">Read the Bible</content:text>
+            <content:button type="url" url="https://www.bible.com/bible/59/MRK.1">
+                <content:text i18n-id="9a926209-6bfc-407f-83e5-5dc04d21f64e">bible.com/bible/59/mrk.1</content:text>
+            </content:button>
+        </content:paragraph>
+
+        <content:paragraph>
+            <content:text i18n-id="0a54d46a-93af-4f0d-804f-4bd48ce5e385" text-align="center">Watch a film about Jesus</content:text>
+            <content:button type="url" url="https://www.jesusfilm.org/watch/jesus.html/english.html">
+                <content:text i18n-id="1c0b32ac-31ba-4606-9de8-05034082e178">jesusfilm.org/watch/jesus.html/english.html</content:text>
+            </content:button>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/sat/1.xml
+++ b/schema_tests/tract/valid/sat/1.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-color="rgba(182,212,224,1)"
+    background-image="satisfied-tract-bkg-image-0_1x.jpg">
+    <hero>
+        <heading>
+            <content:text i18n-id="a3049b50-0a42-46f1-a286-179c8dea2ee6" text-scale="1.8" text-color="rgba(50,50,50,1)" text-align="center">Satisfied?</content:text>
+        </heading>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/sat/2.xml
+++ b/schema_tests/tract/valid/sat/2.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-1_1x.jpg"
+    background-color="rgba(39,51,61,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="c01db8f9-37be-4f6b-9a0c-a10d5f2d56ec"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="645af94c-eee7-4096-bbef-b4ac93f4e1fe"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="c9315a8e-c6b4-4396-809c-fc7036fd8aae"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="c97fec59-c592-4fe1-9cd1-4c66d4cdd1f6">Do you desire more?</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="734c56ea-ffc1-4a0a-b298-4e1d635b7708"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="61d05ed8-8f4a-4767-bf2b-1a4065d5a71e"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="35ac14b0-fc1b-4598-b233-74c1cd37187d"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="a8fc5a97-efb6-42c7-a408-9ded8b20fdbe"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="be5e8347-5b45-4167-9e25-5bd1c0479cc9"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7a7255e6-74cb-46c3-8847-df73976a1a0f"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="c41367b1-591b-48c1-8940-f8d7c619009c"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="3c1f29e9-25ee-49ef-96f5-eec2ca101a6b"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/3.xml
+++ b/schema_tests/tract/valid/sat/3.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-2_1x.jpg"
+    background-color="rgba(11,12,6,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="06daebb2-36c6-4a4c-a458-7da93340d01b"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="42c03470-bc54-4e96-98eb-475bf8bf2b03"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="108e9d2e-6865-4b13-8b0e-79090aca8c6c"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="e56bfff7-8e11-453d-a816-b751f0b2e156"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="1bce670f-3a5c-4ccd-936a-262049fac207"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="e33fd2e5-df96-49ff-bd56-9de4242ed1ed"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="c08044ea-df68-425e-b61c-8eeb350a3520"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="27164f05-daa5-401c-ac2d-24ecdfe73b06"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="4dae880d-34ee-450f-8743-b69a4941621e"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="e8dffc68-6ad0-43da-8f41-5aaabf4f580b"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="7ef2d3f0-3908-474b-84d2-0fab8073e59e"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="5c29963b-baf9-449c-a2d1-82c9fed5122f"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="1d9eb041-3db8-477f-a02e-08a1a1323e76"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="4a943b48-0a8d-4ebd-8d8b-7c13ca0628b2"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="829e23f2-9409-4a02-a1af-4c624ffc83f0"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="7df4495b-3f37-4e30-b5df-21772c5aebef"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="fcee3f74-d7ee-480b-b7df-ba700fa84183"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/4.xml
+++ b/schema_tests/tract/valid/sat/4.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-3_1x.jpg"
+    background-color="rgba(64,47,38,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="131044e1-064a-4e57-accd-4bca7a0917d8"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="f606f6fd-8443-44f1-9cea-b5a38e00577e"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="92cfd63b-4da6-481f-887e-eec3784f5335"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="9c8cfc32-6c7f-4516-8d3a-03cea8ff7b03"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="f735b4aa-5691-4d83-861e-f6c98f721f90"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="44377ff5-2b02-409a-b169-eaa9a1dfdb1f"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="41f67dd2-f053-4a81-900c-09363e0d3934"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="11bb73ff-f34a-462f-a866-c4004ef31c3b"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="051243f6-8d73-4caf-a8f5-4facf1b3ed0b"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="bc49a797-0467-46af-b836-10f930962859"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="55c57d61-164a-4d08-8ff2-0ae0e14cee68"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="7cf39e0e-9ad6-48a5-8e4f-c9452b5e6569"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/5.xml
+++ b/schema_tests/tract/valid/sat/5.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-4_1x.jpg" background-color="rgba(94,79,56,1)"
+    card-text-color="rgba(50,50,50,1)" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://mobile-content-api.cru.org/xmlns/analytics ">
+    <hero>
+        <heading>
+            <content:text i18n-id="2171d7ee-d346-417e-ac4b-ca8ad3c9e906"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="a73de09d-73f6-4866-a0b7-b3ff61d847a1"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="7e6b0467-6ab2-4231-a233-be8299667e17"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="b2c4df2b-77b2-4f57-84ef-1ad7bef3fbc8"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="e56048dc-f8f8-458b-bde9-85ca03e3ee42"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="8f0728a6-e931-4d73-991e-408c03aeea7c"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="61343899-7cb0-4202-8a5e-fb5b40696141"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="7db0e7cc-7948-4b0b-8116-f480c8015a6b"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="c8aa10b8-b386-44eb-ad1b-50c2c35a1d4f"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="54969da5-4168-43df-be20-9818641d4c6a"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="9f90ed09-ddb4-4dd3-a225-3e7dd13d94fd"></content:text>
+            </label>
+            <analytics:events>
+                <analytics:event action="KGP-US Gospel Presented" delay="5" system="adobe firebase">
+                    <analytics:attribute key="" value="" />
+                </analytics:event>
+            </analytics:events>
+            <content:paragraph>
+                <content:text i18n-id="f3803aae-3a90-4636-b56c-0f9e97ce670e"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="dce3ce01-daf0-4f58-9db9-e8efdd44892d"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="750195c7-587d-4e6f-af81-f383b5fc0016"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="f05d29b9-0831-47e7-a550-ea6849d1902c"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="ae703380-9fa2-47fc-bd72-d4ecd01b8f0c"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="76732ef2-2bf1-447e-8c15-bf34e41dcf06"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="27d8462f-d1bf-4766-b216-46a311e98e62"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="762387bf-0b85-4962-b5b2-8a493a25f60b"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/6.xml
+++ b/schema_tests/tract/valid/sat/6.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-5_1x.jpg"
+    background-color="rgba(25,66,75,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="d70fdc91-1e3f-4572-945d-4fd178e3ae6c"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="44e85f5c-fcaa-401b-8d91-ffbb57be4e58"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="ac4c13ef-2d9e-4ef2-bd43-1a8d1e0a2014"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="a1a719a6-7d23-4da8-a180-6a91b5d37741"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="28700be5-6a75-41cb-bd90-8f4d969c06f5"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="df11e7e7-ad66-4e68-b4d7-e5583ecd7f4b"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="3ea26042-4cda-4986-9435-dd96e3e13604"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="b4592c25-9a30-4fee-94b5-52f944477efe"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="114dd44f-c151-421f-96f3-4f9f79de679f"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="70dfee15-929a-4e29-8dc8-4b3953e8f0ed"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="f9b99750-f8a9-4cea-8629-4ca0f235ccf0"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="de604537-b463-4504-9b01-0a1faeecfb78"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7797bdce-943d-4bae-bb89-49805235eb5c"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="009fc75e-1c0c-4277-93e8-ba1d1ab577d5"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="03fe26e8-78c4-484c-aeb4-62192fe14853"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="a9407d04-e046-4dd2-af24-ff3b543332b2"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="f2b405d1-53ce-4152-9b11-b23a327c811b"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="1896d705-2cee-498b-92ae-e2d8d4700e00"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/7.xml
+++ b/schema_tests/tract/valid/sat/7.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-6_1x.jpg"
+    background-color="rgba(27,60,75,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="42678b4c-638c-4bec-b79b-1fd986687f4f"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="7f75f499-eee1-4fbb-b710-45a69090ecc3"></content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text i18n-id="81cb4f6c-5ad8-4752-aced-ace06052db69"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="337761fe-a53d-45f6-9671-7730fc6b22c9"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="82594133-e1aa-49bc-b1f9-49ed6aa19143"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="8bb2c274-f56e-4390-9315-e5993dfee529"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="60178e6a-473c-43c6-948a-9ff550e3ee8d"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="8eb0d1e4-28b0-4197-b91f-0a17f1783efb"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="9b84b400-7b9e-46ac-87c1-0b461afe4be7"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="ba9b9748-6af2-4b79-930e-4a9bc2e6351f"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="48666f77-a858-4c91-b7e6-8bff7505190a"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="668c73bf-960e-43c7-8d44-098435d4e3ea"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="5d35e2dc-526b-4d74-b3b3-a3d5eb7ce7e9"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="9bec6779-5db6-4d2c-b7ae-863439079c97"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="9f42b753-db57-4a8f-992e-03a6fdb41cb0"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="3629b7f7-7ea7-4cf7-a3cc-0f7a0c56644d"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="506d2e46-577c-4cf1-92c8-957152126a64"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="bb0d27de-90e6-4e49-9b82-0892d7e0d44e"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+
+    <call-to-action>
+        <content:text i18n-id="1bb84af2-b3ad-4c74-b41d-6ee180624873"></content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/sat/8.xml
+++ b/schema_tests/tract/valid/sat/8.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="satisfied-tract-bkg-image-7_1x.jpg"
+    background-color="rgba(93,97,101,1)"
+    card-text-color="rgba(50,50,50,1)">
+    <hero>
+        <heading>
+            <content:text i18n-id="976ef295-46ce-4c79-afa7-0c6e141eda35"></content:text>
+        </heading>
+        <content:paragraph>
+            <content:text i18n-id="e2a274bf-1107-4bf1-a355-6b2883c99e35"></content:text>
+        </content:paragraph>
+    </hero>
+
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="65b67b82-8fd8-4f2b-8f9d-313b2e836f75"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="8cc0562b-c4e4-4db2-bb10-ed6f5440632c"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="d2f2a155-10f6-4ab6-9e91-0da19a7df2f4"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="7b3d2b5e-478f-4be0-be58-11e357ba2993"></content:text>
+            </content:paragraph>
+            <content:paragraph>
+                <content:text i18n-id="4f7ddd54-0d79-436d-af0d-8730b03b2015"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="1639f0d8-571d-472d-a15a-4fbe00bc7330"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="7dd80a72-7ebf-41f7-9387-2bf3a7650786"></content:text>
+            </content:paragraph>
+        </card>
+
+        <card>
+            <label>
+                <content:text i18n-id="7741d4c6-433c-492c-9eee-473ee301b116"></content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="5c1304fd-0833-4120-b892-581edc3f6e6a"></content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+</page>

--- a/schema_tests/tract/valid/tests/buttons.xml
+++ b/schema_tests/tract/valid/tests/buttons.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <content:paragraph>
+            <content:button type="url" url="https://www.google.com/">
+                <content:text>text</content:text>
+            </content:button>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/call-to-action.xml
+++ b/schema_tests/tract/valid/tests/call-to-action.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <call-to-action events="ljkasdf test:tast">
+        <content:text i18n-id="fae69b3b-e95b-4184-9bcd-211e35faa71c">Why do you think most people don’t know God personally?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/tests/hero_analytics.xml
+++ b/schema_tests/tract/valid/tests/hero_analytics.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <analytics:events>
+            <analytics:event system="adobe">
+                <analytics:attribute key="a" value="1" />
+            </analytics:event>
+            <analytics:event system="firebase">
+                <analytics:attribute key="a" value="2" />
+            </analytics:event>
+            <analytics:event system="adobe firebase">
+                <analytics:attribute key="a" value="2" />
+            </analytics:event>
+        </analytics:events>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/restrictTo.xml
+++ b/schema_tests/tract/valid/tests/restrictTo.xml
@@ -15,7 +15,7 @@
             <label>
                 <content:text i18n-id="2c1f7198-f0a1-40cb-b71f-b50237866f15">God loves you</content:text>
             </label>
-            <content:paragraph restrictTo="mobile web">
+            <content:paragraph>
                 <content:text i18n-id="8189a000-f7d3-4bc3-8eea-ef826c53dc5c">"God showed how much he loved us by sending his one and only Son into the world so that we might have eternal life through him."</content:text>
                 <content:text i18n-id="4919a9b7-f874-4362-87d5-c59ec8da754c">- 1 John 4:9</content:text>
             </content:paragraph>

--- a/schema_tests/tract/valid/tests/restrictTo.xml
+++ b/schema_tests/tract/valid/tests/restrictTo.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    background-image="kgp-tract-bkg-image-1_1x.jpg">
+    <header>
+        <number>
+            <content:text>1</content:text>
+        </number>
+        <title>
+            <content:text i18n-id="087b7293-70aa-41c7-b6cc-5d397a4eb41b">God loves you and created you to know him personally.</content:text>
+        </title>
+    </header>
+    <cards>
+        <card>
+            <label>
+                <content:text i18n-id="2c1f7198-f0a1-40cb-b71f-b50237866f15">God loves you</content:text>
+            </label>
+            <content:paragraph restrictTo="mobile web">
+                <content:text i18n-id="8189a000-f7d3-4bc3-8eea-ef826c53dc5c">"God showed how much he loved us by sending his one and only Son into the world so that we might have eternal life through him."</content:text>
+                <content:text i18n-id="4919a9b7-f874-4362-87d5-c59ec8da754c">- 1 John 4:9</content:text>
+            </content:paragraph>
+        </card>
+        <card>
+            <label>
+                <content:text i18n-id="f0ab9318-ed38-426d-946d-0668adb55f02">God wants you to know him</content:text>
+            </label>
+            <content:paragraph>
+                <content:text i18n-id="90c1f8d1-39c0-49f8-b905-5bd7e850eef8">“Now this is eternal life: that they may know You, the only true God, and Jesus Christ, whom You have sent.”</content:text>
+                <content:text i18n-id="df32c4e8-e832-4026-870e-cbde62215c5b">John 17:3 NIV</content:text>
+            </content:paragraph>
+        </card>
+    </cards>
+    <call-to-action>
+        <content:text i18n-id="fae69b3b-e95b-4184-9bcd-211e35faa71c">Why do you think most people don’t know God personally?</content:text>
+    </call-to-action>
+</page>

--- a/schema_tests/tract/valid/tests/text_styles.xml
+++ b/schema_tests/tract/valid/tests/text_styles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <content:paragraph>
+            <content:text>Plain Text</content:text>
+            <content:text text-style="">Plain Text</content:text>
+            <content:text text-style="bold">Bold Text</content:text>
+            <content:text text-style="bold italic">Bold Italic Text</content:text>
+            <content:text text-style="bold italic underline">Underline Bold Italic Text</content:text>
+        </content:paragraph>
+    </hero>
+</page>


### PR DESCRIPTION
We currently keep our XML Schemas for GodTools in this repo because they are enforced by the mobile-content-api only.

This PR adds some xmllint tests to ensure changes to the XML schema doesn't break existing tools in unexpected ways.