### PR TITLE
Only clean the db after all tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,15 +71,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-
     Rails.application.load_seed # loading seeds
   end
 
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+  config.after(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
   end
 end


### PR DESCRIPTION
Cleaning (by rollback) was failing intermittently for one test file (spec/models/attachment_spec.rb) due, I assume, to interaction with the seed data.

Having the same db (and seed data) for all tests seems to work reliably even when test order is randomized.