### PR TITLE
disable request forgery on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,7 @@ Rails.application.configure do
 
   # Action cable
   config.secret_key_base = ENV["SECRET_KEY_BASE"]
-  config.action_cable.allowed_request_origins = ["https://mobile-content-api.cru.org"]
+  config.action_cable.disable_request_forgery_protection = true
 end
 
 Rails.application.routes.default_url_options = {


### PR DESCRIPTION
This PR copies the request forgery config from staging to production.