### PR TITLE
Define a training tip type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ jobs:
     # text invalid XML
     - ./schema_tests/invalid.sh public/xmlns/tract.xsd schema_tests/tract/invalid/*/*.xml
     - ./schema_tests/invalid.sh public/xmlns/manifest.xsd schema_tests/manifest/invalid/*/*.xml
+    - ./schema_tests/invalid.sh public/xmlns/training.xsd schema_tests/training/invalid/*/*.xml

--- a/public/xmlns/training.xsd
+++ b/public/xmlns/training.xsd
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/training">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+
+    <xs:simpleType name="tipType">
+        <xs:annotation>
+            <xs:documentation>The possible tip types</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ask" />
+            <xs:enumeration value="consider" />
+            <xs:enumeration value="tip" />
+            <xs:enumeration value="prepare" />
+            <xs:enumeration value="quote" />
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:element name="tip">
         <xs:annotation>
@@ -27,6 +41,11 @@
                     </xs:complexType>
                 </xs:element>
             </xs:all>
+            <xs:attribute name="type" type="training:tipType" default="tip">
+                <xs:annotation>
+                    <xs:documentation>Defines the type of this tip. This defaults to tip.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 

--- a/schema_tests/training/invalid/tests/tip_invalid_type.xml
+++ b/schema_tests/training/invalid/tests/tip_invalid_type.xml
@@ -1,0 +1,3 @@
+<tip xmlns="https://mobile-content-api.cru.org/xmlns/training" type="invalid">
+    <pages />
+</tip>

--- a/schema_tests/training/valid/tests/tip_type.xml
+++ b/schema_tests/training/valid/tests/tip_type.xml
@@ -1,0 +1,3 @@
+<tip xmlns="https://mobile-content-api.cru.org/xmlns/training" type="ask">
+    <pages />
+</tip>


### PR DESCRIPTION
In the figma design there are a few different "types" of tips. This XML schema change is to support defining the type of tip via xml.
<img width="671" alt="Screen Shot 2020-07-17 at 11 44 17 AM" src="https://user-images.githubusercontent.com/47818/87805183-ef73ac00-c822-11ea-92d6-9bcae945d9a1.png">

Sample tip w/ type XML:
```xml
<tip xmlns="https://mobile-content-api.cru.org/xmlns/training" type="ask">
  <pages />
</tip>
```