### PR TITLE
Increase the channel expiration time

### DIFF
--- a/app/channels/base_sharing_channel.rb
+++ b/app/channels/base_sharing_channel.rb
@@ -1,6 +1,6 @@
 class BaseSharingChannel < ApplicationCable::Channel
   METADATA_CACHE_PREFIX = "sharing_metadata"
-  METADATA_EXPIRY = 2.hours
+  METADATA_EXPIRY = 24.hours
   SUBSCRIBER_TO_PUBLISHER = "subscriber_to_publisher"
 
   protected


### PR DESCRIPTION
This helps ensure that users don't accidentally get an invalid channel due to timeout.