### PR TITLE
GT-837 add support for attaching tips to a tract header

### DIFF
--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -122,6 +122,7 @@
             <xs:element name="title" type="content:textChild" />
         </xs:sequence>
         <xs:attribute name="background-color" type="content:colorValue" use="optional" />
+        <xs:attributeGroup ref="training:tractHeader" />
     </xs:complexType>
 
     <!--

--- a/public/xmlns/training.xsd
+++ b/public/xmlns/training.xsd
@@ -60,6 +60,18 @@
             </xs:element>
         </xs:choice>
     </xs:group>
+    <xs:attributeGroup name="tractHeader">
+        <xs:annotation>
+            <xs:documentation>This attribute group is the set of attributes that can appear on the header
+                element in the tract page xml.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute ref="training:tip">
+            <xs:annotation>
+                <xs:documentation>This defines a tip associated with this header element</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
     <xs:attributeGroup name="tractCallToAction">
         <xs:annotation>
             <xs:documentation>This attribute group is the set of attributes that can appear on the call-to-action

--- a/schema_tests/tract/valid/tests/header_training_tip.xml
+++ b/schema_tests/tract/valid/tests/header_training_tip.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training">
+    <header training:tip="tip1">
+        <title>
+            <content:text i18n-id="087b7293-70aa-41c7-b6cc-5d397a4eb41b">God loves you and created you to know him personally.</content:text>
+        </title>
+    </header>
+</page>


### PR DESCRIPTION
This PR makes it possible to specify a tip for a page header. example xml:
```xml
<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
    xmlns:training="https://mobile-content-api.cru.org/xmlns/training">
    <header training:tip="tip1">
        <title><content:text>header</content:text></title>
    </header>
</page>
```