### PR TITLE
GT-941 make it possible to restrict content to android or ios exclusively

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -139,6 +139,16 @@
                     <xs:documentation>This device type represents a native app on Android or iOS</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
+            <xs:enumeration value="android">
+                <xs:annotation>
+                    <xs:documentation>This device type represents a native app on Android</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ios">
+                <xs:annotation>
+                    <xs:documentation>This device type represents a native app on iOS</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
             <xs:enumeration value="web">
                 <xs:annotation>
                     <xs:documentation>This device type represents a web browser</xs:documentation>

--- a/schema_tests/tract/valid/tests/restrictTo.xml
+++ b/schema_tests/tract/valid/tests/restrictTo.xml
@@ -9,8 +9,10 @@
             <content:image resource="a.jpg" restrictTo="web" />
             <content:text i18n-id="087b7293-70aa-41c7-b6cc-5d397a4eb41b" restrictTo="web mobile">God loves you and created you to know him personally.</content:text>
             <content:paragraph restrictTo="mobile">
-                <content:text />
+                <content:text restrictTo="ios" />
+                <content:image resource="a.jpg" restrictTo="android" />
             </content:paragraph>
+            <content:image resource="a.jpg" restrictTo="android web" />
         </content:paragraph>
     </hero>
 </page>


### PR DESCRIPTION
This adds on the ability to further restrict content to only 1 mobile platform instead of both.

```xml
<content:button type="url" url="https://questions-about-god-deeplink.com" restrictTo="android" />
```