### PR TITLE
GT-941 Fallback content spec

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -185,6 +185,14 @@
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:group ref="content:elements" />
             </xs:choice>
+            <xs:attribute name="fallback" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation>When fallback is set to true this paragraph node should be treated by the renderer
+                        as a fallback content node. This is meant to provide temporary transition support for the new
+                        fallback mode before it is widely supported by deployed apps.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attributeGroup ref="content:contentRestrictions" />
         </xs:complexType>
     </xs:element>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -425,6 +425,19 @@
         <xs:attribute name="value" type="xs:string" use="optional" />
     </xs:complexType>
 
+    <xs:element name="fallback">
+        <xs:annotation>
+            <xs:documentation>This tag provides fallback rendering behavior. The renderer should render the first
+                element that is supported and meets any specified content restrictions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:group ref="content:elements" />
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+
     <!-- Content Elements -->
     <xs:element name="tabs" type="content:tabs" />
     <xs:element name="text">
@@ -451,6 +464,7 @@
             <xs:element ref="content:link" />
             <xs:element ref="content:form" />
             <xs:element ref="content:input" />
+            <xs:element ref="content:fallback" />
             <xs:group ref="training:contentElements" />
         </xs:choice>
     </xs:group>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -175,13 +175,17 @@
     </xs:attributeGroup>
 
     <!-- element nodes -->
-    <!-- Paragraph - Vertical stack of content with margin/padding on the top and bottom -->
-    <xs:complexType name="paragraph">
-        <xs:choice minOccurs="1" maxOccurs="unbounded">
-            <xs:group ref="content:elements" />
-        </xs:choice>
-        <xs:attributeGroup ref="content:deviceRestrictions" />
-    </xs:complexType>
+    <xs:element name="paragraph">
+        <xs:annotation>
+            <xs:documentation>Vertical stack of content with margin/padding on the top and bottom.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:group ref="content:elements" />
+            </xs:choice>
+            <xs:attributeGroup ref="content:deviceRestrictions" />
+        </xs:complexType>
+    </xs:element>
 
     <!-- Tabbed content -->
     <xs:complexType name="tabs">
@@ -420,7 +424,6 @@
     </xs:complexType>
 
     <!-- Content Elements -->
-    <xs:element name="paragraph" type="content:paragraph" />
     <xs:element name="tabs" type="content:tabs" />
     <xs:element name="text">
         <xs:complexType>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -201,7 +201,8 @@
                 <xs:annotation>
                     <xs:documentation>When fallback is set to true this paragraph node should be treated by the renderer
                         as a fallback content node. This is meant to provide temporary transition support for the new
-                        fallback mode before it is widely supported by deployed apps.
+                        fallback mode before it is widely supported by deployed apps. This backwards compatibility is
+                        scheduled for removal after December 2021.
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -318,7 +318,9 @@
                 </xs:sequence>
                 <xs:attribute name="type" use="required">
                     <xs:annotation>
-                        <xs:documentation>This attribute determines what type of button this is.</xs:documentation>
+                        <xs:documentation>This attribute determines what type of button this is. Unrecognized button
+                            types should be treated as unsupported by the renderer.
+                        </xs:documentation>
                     </xs:annotation>
                     <xs:simpleType>
                         <xs:restriction base="xs:string">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -173,6 +173,18 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="minimumRendererVersion" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>This attribute can be used when a backwards incompatible change to an element is made
+                    and we want to restrict rendering the element to newer versions of the renderer only.
+
+                    The current renderer version is 1.
+
+                    Version History:
+                    1: Base version, no backwards incompatible changes have been made yet.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
     <!-- endregion Common Attributes -->
 

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -165,7 +165,7 @@
     <!-- endregion Value Definitions -->
 
     <!-- region Common Attributes -->
-    <xs:attributeGroup name="deviceRestrictions">
+    <xs:attributeGroup name="contentRestrictions">
         <xs:attribute name="restrictTo" type="content:deviceTypes">
             <xs:annotation>
                 <xs:documentation>This attribute specifies that the element it is on is only rendered on the specified
@@ -185,7 +185,7 @@
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:group ref="content:elements" />
             </xs:choice>
-            <xs:attributeGroup ref="content:deviceRestrictions" />
+            <xs:attributeGroup ref="content:contentRestrictions" />
         </xs:complexType>
     </xs:element>
 
@@ -266,7 +266,7 @@
                 <xs:documentation>This attribute defines the events to trigger when the user "clicks" the image.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attributeGroup ref="content:deviceRestrictions" />
+        <xs:attributeGroup ref="content:contentRestrictions" />
     </xs:complexType>
 
     <!-- Button -->
@@ -349,7 +349,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attributeGroup ref="content:deviceRestrictions" />
+                <xs:attributeGroup ref="content:contentRestrictions" />
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -431,7 +431,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="content:text">
-                    <xs:attributeGroup ref="content:deviceRestrictions" />
+                    <xs:attributeGroup ref="content:contentRestrictions" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -7,7 +7,7 @@
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/training" schemaLocation="training.xsd" />
 
-    <!-- Value definitions -->
+    <!-- region Value Definitions -->
     <xs:simpleType name="colorValue">
         <xs:restriction base="xs:string">
             <xs:pattern value="rgba\([0-9]{1,3},\s*[0-9]{1,3},\s*[0-9]{1,3},\s*([01]|0?\.[0-9]*)\)" />
@@ -162,8 +162,9 @@
         </xs:annotation>
         <xs:list itemType="content:deviceType" />
     </xs:simpleType>
+    <!-- endregion Value Definitions -->
 
-    <!-- common attributes -->
+    <!-- region Common Attributes -->
     <xs:attributeGroup name="deviceRestrictions">
         <xs:attribute name="restrictTo" type="content:deviceTypes">
             <xs:annotation>
@@ -173,6 +174,7 @@
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
+    <!-- endregion Common Attributes -->
 
     <!-- element nodes -->
     <xs:element name="paragraph">

--- a/schema_tests/tract/invalid/tests/minimumRendererVersion_not_an_int.xml
+++ b/schema_tests/tract/invalid/tests/minimumRendererVersion_not_an_int.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph minimumRendererVersion="a">
+            <content:text />
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/fallback.xml
+++ b/schema_tests/tract/valid/tests/fallback.xml
@@ -4,6 +4,7 @@
     <hero>
         <content:paragraph>
             <content:fallback>
+                <content:text minimumRendererVersion="2">New Renderer</content:text>
                 <content:text restrictTo="android">Android</content:text>
                 <content:text restrictTo="ios">iOS</content:text>
                 <content:text>Unknown</content:text>

--- a/schema_tests/tract/valid/tests/fallback.xml
+++ b/schema_tests/tract/valid/tests/fallback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:fallback>
+                <content:text restrictTo="android">Android</content:text>
+                <content:text restrictTo="ios">iOS</content:text>
+                <content:text>Unknown</content:text>
+            </content:fallback>
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/fallback_paragraph.xml
+++ b/schema_tests/tract/valid/tests/fallback_paragraph.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:paragraph fallback="true">
+                <content:text restrictTo="android">Android</content:text>
+                <content:text restrictTo="ios">iOS</content:text>
+                <content:text>Unknown</content:text>
+            </content:paragraph>
+        </content:paragraph>
+    </hero>
+</page>


### PR DESCRIPTION
`<content:fallback/>` nodes provide a mechanism to define fallback for content that may not be supported on a renderer or device. To provide backwards compatibility for older renderers we are also introducing a `fallback` attribute on a paragraph element that will tell the renderer to treat that paragraph as a `<content:fallback />` element instead.

### Examples

This will render "Android" on `android` devices, "iOS" on `ios` devices, and "Unknown" on all other devices (e.g. web)
```xml
<content:fallback>
    <content:text restrictTo="android">Android</content:text>
    <content:text restrictTo="ios">iOS</content:text>
    <content:text>Unknown</content:text>
</content:fallback>
```

The same example utilizing a `<content:paragraph />` element
```xml
<content:paragraph fallback="true">
    <content:text restrictTo="android">Android</content:text>
    <content:text restrictTo="ios">iOS</content:text>
    <content:text>Unknown</content:text>
</content:paragraph>
```

This will render the `newtype` button when the renderer supports that type. on devices that don't support `newtype` buttons, it will render the text node instead.
```xml
<content:fallback>
    <content:button type="newtype" />
    <content:text>Button not supported</content:text>
</content:fallback>
```

This will render an element on newer versions of the renderer only. This will be used if we ever start introducing backwards-incompatible changes.
```xml
<content:fallback>
    <content:text minimumRendererVersion="2">This text will <b>only</b> render when the renderer is at least version 2</content:text>
    <content:text>This text will render for any older versions of the renderer</content:text>
</content:fallback>
```