### PR TITLE
Make sure to rescue from error in production

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -32,7 +32,7 @@ class Attachment < ActiveRecord::Base
 
   def generate_sha256
     XmlUtil.filename_sha(URI.parse(url).open.read)
-  rescue NoMethodError
+  rescue NoMethodError, OpenURI::HTTPError
     file = attachment_changes["file"].attachable
     file ||= url
     XmlUtil.filename_sha(File.open(file).read)


### PR DESCRIPTION
It seems the the errors from the test suite and production differ, so this should fix the issue with uploading attachments.