### PR TITLE
GT-1030 Support start & end images on text nodes

### DIFF
--- a/app/lib/package.rb
+++ b/app/lib/package.rb
@@ -6,7 +6,9 @@ class Package
   XPATH_RESOURCES = %w[//@background-image
     //manifest:category/@banner
     //content:animation/@resource
-    //content:image[not(@restrictTo='web')]/@resource].freeze
+    //content:image[not(@restrictTo='web')]/@resource
+    //content:text/@image-start
+    //content:text/@image-end].freeze
   XPATH_TIPS = %w[//training:tip/@id
     //tract:header/@training:tip
     //tract:call-to-action/@training:tip].freeze

--- a/app/lib/package.rb
+++ b/app/lib/package.rb
@@ -7,8 +7,8 @@ class Package
     //manifest:category/@banner
     //content:animation/@resource
     //content:image[not(@restrictTo='web')]/@resource
-    //content:text/@image-start
-    //content:text/@image-end].freeze
+    //content:text/@start-image
+    //content:text/@end-image].freeze
   XPATH_TIPS = %w[//training:tip/@id
     //tract:header/@training:tip
     //tract:call-to-action/@training:tip].freeze

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -246,11 +246,11 @@
 
     <xs:element name="text">
         <xs:complexType>
-            <xs:complexContent>
+            <xs:simpleContent>
                 <xs:extension base="content:textType">
                     <xs:attributeGroup ref="content:baseAttributes" />
                 </xs:extension>
-            </xs:complexContent>
+            </xs:simpleContent>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="textType">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -244,23 +244,41 @@
         </xs:sequence>
     </xs:complexType>
 
-    <!--
-        Text Content
-            i18n-id:    OPTIONAL - OneSky translation id
-            text-color: DEFAULT( inherit text-color )
-            text-scale: DEFAULT( inherit text-scale )
-    -->
-    <xs:complexType name="text">
+    <xs:element name="text">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="content:textType">
+                    <xs:attributeGroup ref="content:baseAttributes" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="textType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="i18n-id" type="xs:string" use="optional" />
+                <xs:attribute name="i18n-id" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Defines the OneSky translation id for this text.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
                 <xs:attribute name="text-align" type="content:textAlign" use="optional">
                     <xs:annotation>
                         <xs:documentation>Defines the alignment of the text. This defaults to start.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="text-color" type="content:colorValue" use="optional" />
-                <xs:attribute name="text-scale" type="xs:float" use="optional" />
+                <xs:attribute name="text-color" type="content:colorValue">
+                    <xs:annotation>
+                        <xs:documentation>Defines the color of the text. This defaults to the text-color of the closest
+                            ancestor container unless otherwise specified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="text-scale" type="xs:float" default="1.0">
+                    <xs:annotation>
+                        <xs:documentation>Defines how much to scale the font size by. This defaults to 1.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
                 <xs:attribute name="text-style" type="content:textStyles" default="">
                     <xs:annotation>
                         <xs:documentation>Defines any typeface styles to apply to this text content.</xs:documentation>
@@ -271,7 +289,7 @@
     </xs:complexType>
     <xs:complexType name="textChild">
         <xs:sequence>
-            <xs:element name="text" type="content:text" />
+            <xs:element name="text" type="content:textType" />
         </xs:sequence>
     </xs:complexType>
 
@@ -536,15 +554,6 @@
 
     <!-- Content Elements -->
     <xs:element name="tabs" type="content:tabs" />
-    <xs:element name="text">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="content:text">
-                    <xs:attributeGroup ref="content:baseAttributes" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
     <xs:element name="link" type="content:link" />
     <xs:element name="form" type="content:form" />
     <xs:element name="input" type="content:input" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -248,17 +248,41 @@
         <xs:complexType>
             <xs:simpleContent>
                 <xs:extension base="content:textType">
-                    <xs:attribute name="image-start" type="xs:string">
+                    <xs:attribute name="start-image" type="xs:string">
                         <xs:annotation>
                             <xs:documentation>Defines an image to display to the "start" of this text node.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="image-end" type="xs:string">
+                    <xs:attribute name="start-image-size" default="40">
+                        <xs:annotation>
+                            <xs:documentation>Defines the size in "density-independent pixels"/"points" of the start
+                                image. This defaults to 40.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:int">
+                                <xs:pattern value="[1-9][0-9]*" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="end-image" type="xs:string">
                         <xs:annotation>
                             <xs:documentation>Defines an image to display to the "end" of this text node.
                             </xs:documentation>
                         </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="end-image-size" default="40">
+                        <xs:annotation>
+                            <xs:documentation>Defines the size in "density-independent pixels"/"points" of the end
+                                image. This defaults to 40.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:int">
+                                <xs:pattern value="[1-9][0-9]*" />
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:attribute>
                     <xs:attributeGroup ref="content:baseAttributes" />
                 </xs:extension>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -248,6 +248,18 @@
         <xs:complexType>
             <xs:simpleContent>
                 <xs:extension base="content:textType">
+                    <xs:attribute name="image-start" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>Defines an image to display to the "start" of this text node.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="image-end" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>Defines an image to display to the "end" of this text node.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                     <xs:attributeGroup ref="content:baseAttributes" />
                 </xs:extension>
             </xs:simpleContent>

--- a/schema_tests/tract/invalid/tests/text_start_image_size_negative.xml
+++ b/schema_tests/tract/invalid/tests/text_start_image_size_negative.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <content:paragraph>
+            <content:text start-image-size="-10" />
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/invalid/tests/text_start_image_size_zero.xml
+++ b/schema_tests/tract/invalid/tests/text_start_image_size_zero.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <content:paragraph>
+            <content:text start-image-size="0" />
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/text_inline_images.xml
+++ b/schema_tests/tract/valid/tests/text_inline_images.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    <hero>
+        <content:paragraph>
+            <content:text start-image="test.png">Start Image</content:text>
+            <content:text start-image="test.png" start-image-size="32">Start Image</content:text>
+            <content:text end-image="test.png">End Image</content:text>
+            <content:text end-image="test.png" end-image-size="32">End Image</content:text>
+        </content:paragraph>
+    </hero>
+</page>


### PR DESCRIPTION
Sample xml:
```
          <content:text start-image="image.png"><- Image should be here</content:text>
          <content:text start-image="image.png" start-image-size="16"><- Image should be here</content:text>
          <content:text end-image="image.png">Image should be here -></content:text>
          <content:text end-image="image.png" end-image-size="16">Image should be here -></content:text>
```