### PR TITLE
GT-1054 add an outlined button style to the content spec

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -347,8 +347,7 @@
                 <xs:extension base="content:textChild">
                     <xs:annotation>
                         <xs:documentation>The content:text child element is the text content of this button. The
-                            text-color attribute defaults to the primary-text-color of the closest ancestor container.
-                            The text-align attribute for buttons defaults to center.
+                            text-align attribute for buttons defaults to center.
                         </xs:documentation>
                     </xs:annotation>
                     <xs:sequence>
@@ -402,10 +401,46 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                    <xs:attribute name="style" default="contained">
+                        <xs:annotation>
+                            <xs:documentation>This attribute defines the style of the button. It defaults to "contained"
+                                unless otherwise specified.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="contained">
+                                    <xs:annotation>
+                                        <xs:documentation>This is a solid color button. The button color defines the
+                                            solid color for this button. The button text-color defaults to the
+                                            primary-text-color of the closest styles ancestor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                                <xs:enumeration value="outlined">
+                                    <xs:annotation>
+                                        <xs:documentation>This is an outlined button. The button color defines the
+                                            outline color for this button. The button text-color defaults to the
+                                            color of this button.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:enumeration>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                     <xs:attribute name="color" type="content:colorValue" use="optional">
                         <xs:annotation>
                             <xs:documentation>This attribute determines the color of the button. This defaults to the
-                                primary-color of the closest ancestor container.
+                                button-color of the closest ancestor element. If button-color is not defined in the
+                                element hierarchy the color then defaults to the primary-color of the closest ancestor
+                                element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="background-color" type="content:colorValue" default="rgba(0,0,0,0)">
+                        <xs:annotation>
+                            <xs:documentation>This attribute determines the background color of outlined buttons. This
+                                defaults to rgba(0,0,0,0).
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -247,8 +247,16 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <!-- Modal - a Modal that is displayed when it's listener is triggered -->
     <xs:complexType name="modal">
+        <xs:annotation>
+            <xs:documentation>A modal that is displayed when it's listener is triggered. Modals have the following
+                default styles:
+                - button-color defaults to rgba(255,255,255,1)
+                - primary-color defaults to rgba(0,0,0,0)
+                - primary-text-color defaults to rgba(255,255,255,1)
+                - Buttons default to the outlined style
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="title" minOccurs="0" maxOccurs="1">
                 <xs:annotation>


### PR DESCRIPTION
This adds the ability to specify a button "style" that controls rendering.

<img width="398" alt="Screen Shot 2021-01-25 at 4 35 40 PM" src="https://user-images.githubusercontent.com/47818/105769196-753b8700-5f2b-11eb-8014-0aadd8bac9ba.png">

```xml
<content:button style="outlined"><content:text>Close lesson</content:text></content:text>
<content:button style="outlined"><content:text>Replay lesson</content:text></content:text>
<content:button><content:text>Things to try</content:text></content:text>
```

other examples:
```xml
<content:button style="outlined" color="rgba(255,0,0,1)"><content:text>Red Button</content:text></content:button>
<content:button style="outlined" color="rgba(255,0,0,1)" background-color="rgba(0,0,255,0.2)"><content:text>Red outline w/ light-blue background</content:text></content:button>
```