### PR TITLE
GT-1081 enable strict XML validation

### DIFF
--- a/app/validators/xml_validator.rb
+++ b/app/validators/xml_validator.rb
@@ -2,9 +2,12 @@
 
 class XmlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    xml_errors = xsd(record).validate(Nokogiri::XML(value))
+    xml = Nokogiri::XML(value) { |config| config.strict }
+    xml_errors = xsd(record).validate(xml)
 
     xml_errors.each { |e| record.errors.add(attribute, e.to_s) }
+  rescue Nokogiri::XML::SyntaxError => e
+    record.errors.add(attribute, e.to_s)
   end
 
   private

--- a/spec/models/abstract_page_spec.rb
+++ b/spec/models/abstract_page_spec.rb
@@ -3,17 +3,23 @@
 require "rails_helper"
 
 describe AbstractPage do
-  it "validates XML on create" do
-    result = Page.create(filename: "test.xml", resource_id: 1, structure: "invalid XML", position: 1)
+  it "validates XML strictly" do
+    result = Page.create(filename: "test.xml", resource_id: 1, structure: "<open>", position: 1)
 
-    expect(result.errors["structure"]).to include("-1:0: ERROR: The document has no document element.")
+    expect(result.errors["structure"]).to include("1:7: FATAL: EndTag: '</' not found")
+  end
+
+  it "validates XML on create" do
+    result = Page.create(filename: "test.xml", resource_id: 1, structure: "<page />", position: 1)
+
+    expect(result.errors["structure"]).to include("1:0: ERROR: Element 'page': No matching global declaration available for the validation root.")
   end
 
   it "validates XML on update" do
     custom_page = CustomPage.find(1)
 
-    custom_page.update(structure: "invalid XML")
+    custom_page.update(structure: "<page />")
 
-    expect(custom_page.errors["structure"]).to include("-1:0: ERROR: The document has no document element.")
+    expect(custom_page.errors["structure"]).to include("1:0: ERROR: Element 'page': No matching global declaration available for the validation root.")
   end
 end


### PR DESCRIPTION
Previously the API would accept some badly formed XML.

For example, the following XML would be accepted as valid even though it didn't have a closing tag:
```xml
<page xmlns="https://mobile-content-api.cru.org">
```