### PR TITLE
GT-1106 support defining dismiss-listeners for manifests to close a tool

### DIFF
--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -130,6 +130,12 @@
             </xs:annotation>
         </xs:attribute>
 
+        <xs:attribute name="dismiss-listeners" type="content:listenersType">
+            <xs:annotation>
+                <xs:documentation>This attribute defines events that will dismiss this tool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <!-- Import any external groups of attributes we want to support -->
         <xs:attributeGroup ref="tract:manifest" />
     </xs:complexType>


### PR DESCRIPTION
```xml
<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest" dismiss-listeners="event_name" />
```