### PR TITLE
GT-1147 Add text-scale attribute to manifest and pages

### DIFF
--- a/public/xmlns/lesson.xsd
+++ b/public/xmlns/lesson.xsd
@@ -50,6 +50,12 @@
                 </xs:annotation>
             </xs:attribute>
 
+            <xs:attribute name="text-scale" type="xs:float" default="1">
+                <xs:annotation>
+                    <xs:documentation>Defines how much to scale all the text content on this page by.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+
             <xs:attribute name="hidden" type="xs:boolean" default="false">
                 <xs:annotation>
                     <xs:documentation>Is this page hidden until triggered by a listener.</xs:documentation>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -90,6 +90,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
         <xs:attribute name="background-color" type="content:colorValue" default="rgba(255,255,255,1)">
             <xs:annotation>
                 <xs:documentation>This is the background color for this tool. This is the bottom-most background
@@ -110,6 +111,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
         <xs:attribute name="navbar-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This defines the color of the application navigation bar for this tool. For lesson
@@ -126,9 +128,16 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
         <xs:attribute name="category-label-color" type="content:colorValue">
             <xs:annotation>
                 <xs:documentation>The category label color. This defaults to text-color.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="text-scale" type="xs:float" default="1">
+            <xs:annotation>
+                <xs:documentation>Defines how much to scale all the text content in this tool by.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
 

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -52,6 +52,7 @@
         <xs:attribute name="primary-color" type="content:colorValue" use="optional" />
         <xs:attribute name="primary-text-color" type="content:colorValue" use="optional" />
         <xs:attribute name="text-color" type="content:colorValue" use="optional" />
+
         <xs:attribute name="background-color" type="content:colorValue" default="rgba(255, 255, 255, 0)">
             <xs:annotation>
                 <xs:documentation>This defines the background color for this page. This background color is layered on
@@ -72,6 +73,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
+        <xs:attribute name="text-scale" type="xs:float" default="1">
+            <xs:annotation>
+                <xs:documentation>Defines how much to scale all the text content on this page by.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:attribute name="card-text-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This attribute defines the text color for cards on this page. This will default to the
@@ -182,6 +190,7 @@
                 <xs:element ref="content:form" />
             </xs:choice>
         </xs:sequence>
+
         <xs:attribute name="background-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This sets the background color of this card. This will default to the
@@ -203,6 +212,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
         <xs:attribute name="text-color" type="content:colorValue" use="optional">
             <xs:annotation>
                 <xs:documentation>This attribute defines the text-color for this card. This will default to the
@@ -210,6 +220,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
         <!-- hidden: DEFAULT( false ) whether this card is hidden. hidden cards can still be displayed if they have a listener that is triggered. -->
         <xs:attribute name="hidden" type="xs:boolean" use="optional" />
         <xs:attribute name="listeners" type="content:listenersType" use="optional">

--- a/schema_tests/lesson/valid/tests/text_attrs.xml
+++ b/schema_tests/lesson/valid/tests/text_attrs.xml
@@ -1,0 +1,3 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" text-scale="1.2345">
+    <content />
+</page>

--- a/schema_tests/manifest/valid/tests/text_attrs.xml
+++ b/schema_tests/manifest/valid/tests/text_attrs.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest" text-scale="1.2345"
+    text-color="rgba(255,0,255,1)" />

--- a/schema_tests/tract/valid/tests/text_styles.xml
+++ b/schema_tests/tract/valid/tests/text_styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <page xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns="https://mobile-content-api.cru.org/xmlns/tract">
+    xmlns="https://mobile-content-api.cru.org/xmlns/tract" text-scale="1.2345">
     <hero>
         <content:paragraph>
             <content:text>Plain Text</content:text>


### PR DESCRIPTION
Define text-scale attributes for the manifest, lesson pages, and tract pages. To calculate the final size of text content you would perform the following calculation:
`{text.textScale} * {page.textScale} * {manifest.textScale} * {base text_size}`

Samples

Manifest:
```xml
<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest" text-scale="1.2345" />
```

Lesson Page:
```xml
<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" text-scale="1.2345">
    <content />
</page>
```

Tract Page:
```xml
<page xmlns="https://mobile-content-api.cru.org/xmlns/tract" text-scale="1.2345" />
```