### PR TITLE
GT-1148 Support a fixed height mode for the content spacer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
     - xmllint --schema public/xmlns/tract.xsd --noout schema_tests/tract/valid/*/*.xml
     - xmllint --schema public/xmlns/training.xsd --noout schema_tests/training/valid/*/*.xml
     # text invalid XML
+    - ./schema_tests/invalid.sh public/xmlns/lesson.xsd schema_tests/lesson/invalid/*/*.xml
     - ./schema_tests/invalid.sh public/xmlns/manifest.xsd schema_tests/manifest/invalid/*/*.xml
     - ./schema_tests/invalid.sh public/xmlns/tract.xsd schema_tests/tract/invalid/*/*.xml
     - ./schema_tests/invalid.sh public/xmlns/training.xsd schema_tests/training/invalid/*/*.xml

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -201,6 +201,7 @@
         <xs:complexType>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:group ref="content:elements" />
+                <xs:group ref="content:fixedSpacerOnly" />
             </xs:choice>
             <xs:attribute name="fallback" type="xs:boolean" default="false">
                 <xs:annotation>
@@ -231,6 +232,7 @@
                             </xs:element>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="content:elements" />
+                                <xs:group ref="content:fixedSpacerOnly" />
                             </xs:choice>
                         </xs:sequence>
                         <xs:attribute name="listeners" type="content:listenersType">
@@ -253,6 +255,7 @@
                             <xs:element name="header" type="content:textChild" />
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="content:elements" />
+                                <xs:group ref="content:fixedSpacerOnly" />
                             </xs:choice>
                         </xs:sequence>
                     </xs:complexType>
@@ -557,6 +560,7 @@
         </xs:annotation>
         <xs:choice maxOccurs="unbounded">
             <xs:group ref="content:elements" />
+            <xs:group ref="content:fixedSpacerOnly" />
         </xs:choice>
     </xs:complexType>
 
@@ -601,10 +605,12 @@
         <xs:complexType>
             <xs:choice maxOccurs="unbounded">
                 <xs:group ref="content:elements" />
+                <xs:group ref="content:fixedSpacerOnly" />
             </xs:choice>
         </xs:complexType>
     </xs:element>
 
+    <!-- region spacer -->
     <xs:element name="spacer">
         <xs:annotation>
             <xs:documentation>This tag can be used to vertically space content.</xs:documentation>
@@ -642,6 +648,23 @@
             </xs:attribute>
         </xs:complexType>
     </xs:element>
+    <xs:group name="fixedSpacerOnly">
+        <xs:choice>
+            <xs:element name="spacer">
+                <xs:complexType>
+                    <xs:attribute name="mode" type="xs:string" use="required" fixed="fixed" />
+                    <xs:attribute name="height" default="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:int">
+                                <xs:minInclusive value="0" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+    <!-- endregion spacer -->
 
     <!-- Content Elements -->
     <xs:element name="link" type="content:link" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -607,11 +607,40 @@
 
     <xs:element name="spacer">
         <xs:annotation>
-            <xs:documentation>This tag can be used to vertically space content. The renderer should evenly split any
-                excess vertical whitespace between all spacer elements in a container.
-            </xs:documentation>
+            <xs:documentation>This tag can be used to vertically space content.</xs:documentation>
         </xs:annotation>
-        <xs:complexType />
+        <xs:complexType>
+            <xs:attribute name="mode" default="auto">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="auto">
+                            <xs:annotation>
+                                <xs:documentation>The renderer should evenly split any excess vertical whitespace
+                                    between all spacer elements in a container that are using the auto mode.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="fixed">
+                            <xs:annotation>
+                                <xs:documentation>This element takes up vertical space specified by the height in
+                                    density independent pixels
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="height" default="0">
+                <xs:annotation>
+                    <xs:documentation>The height of this spacer</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:int">
+                        <xs:minInclusive value="0" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
     </xs:element>
 
     <!-- Content Elements -->

--- a/public/xmlns/lesson.xsd
+++ b/public/xmlns/lesson.xsd
@@ -10,8 +10,8 @@
                 <xs:element name="content">
                     <xs:complexType>
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                            <xs:element ref="content:spacer" minOccurs="0" />
                             <xs:group ref="content:elements" />
+                            <xs:element ref="content:spacer" minOccurs="0" />
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>

--- a/public/xmlns/training.xsd
+++ b/public/xmlns/training.xsd
@@ -34,6 +34,7 @@
                                 <xs:complexType>
                                     <xs:choice minOccurs="0" maxOccurs="unbounded">
                                         <xs:group ref="content:elements" />
+                                        <xs:group ref="content:fixedSpacerOnly" />
                                     </xs:choice>
                                 </xs:complexType>
                             </xs:element>

--- a/schema_tests/lesson/invalid/tests/spacer_negative.xml
+++ b/schema_tests/lesson/invalid/tests/spacer_negative.xml
@@ -1,0 +1,5 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content>
+        <content:spacer mode="fixed" height="-20" />
+    </content>
+</page>

--- a/schema_tests/lesson/invalid/tests/spacer_paragraph.xml
+++ b/schema_tests/lesson/invalid/tests/spacer_paragraph.xml
@@ -1,6 +1,8 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <content>
-        <!-- spacers cannot have negative heights -->
-        <content:spacer mode="fixed" height="-20" />
+        <content:paragraph>
+            <!-- spacers need to specify the mode within paragraphs -->
+            <content:spacer />
+        </content:paragraph>
     </content>
 </page>

--- a/schema_tests/lesson/invalid/tests/spacer_paragraph_auto.xml
+++ b/schema_tests/lesson/invalid/tests/spacer_paragraph_auto.xml
@@ -1,0 +1,8 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content>
+        <content:paragraph>
+            <!-- auto spacers are not currently supported in paragraphs -->
+            <content:spacer mode="auto" />
+        </content:paragraph>
+    </content>
+</page>

--- a/schema_tests/lesson/valid/tests/spacers.xml
+++ b/schema_tests/lesson/valid/tests/spacers.xml
@@ -1,5 +1,6 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <content>
+        <content:spacer mode="fixed" height="20" />
         <content:text />
         <content:spacer />
         <content:text />

--- a/schema_tests/lesson/valid/tests/spacers.xml
+++ b/schema_tests/lesson/valid/tests/spacers.xml
@@ -2,10 +2,13 @@
     <content>
         <content:spacer mode="fixed" height="20" />
         <content:text />
-        <content:spacer />
+        <content:spacer mode="auto" />
         <content:text />
         <content:spacer />
         <content:spacer />
         <content:text />
+        <content:paragraph>
+            <content:spacer mode="fixed" height="20" />
+        </content:paragraph>
     </content>
 </page>


### PR DESCRIPTION
Examples:

Auto-sized spacers:
```xml
<content:spacer />
<content:spacer mode="auto" />
```

Fixed-size spacers:
```xml
<content:spacer mode="fixed" height="40" />
```