### PR TITLE
GT-1180 Create a multi-select content element

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -554,6 +554,14 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="selected-color" type="content:colorValue">
+                            <xs:annotation>
+                                <xs:documentation>This determines the selected color of this Option. This defaults to
+                                    the Multiselect option-selected-color, or the primary color of the closest ancestor
+                                    container with 100% alpha and the lightness of the HSL color space increased by 40%.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                         <xs:attribute name="value" type="xs:string" use="required" />
                     </xs:complexType>
                 </xs:element>
@@ -574,6 +582,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="option-selected-color" type="content:colorValue">
+                <xs:annotation>
+                    <xs:documentation>This determines the default selected color of options in this multiselect element.
+                        This defaults to the multiselect-option-selected-color defined on the closest ancestor
+                        container.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
         <xs:unique name="optionValue">
             <xs:selector xpath="content:option" />
@@ -582,6 +598,7 @@
     </xs:element>
 
     <xs:attribute name="multiselect-option-background-color" type="content:colorValue" />
+    <xs:attribute name="multiselect-option-selected-color" type="content:colorValue" />
     <!-- endregion multiselect -->
 
     <!-- Link -->
@@ -757,6 +774,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute ref="content:multiselect-option-selected-color">
+            <xs:annotation>
+                <xs:documentation>This defines the default multiselect option-selected-color for this page. This
+                    attribute defaults to the Manifest multiselect-option-selected-color.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
 
     <xs:attributeGroup name="manifest">
@@ -764,6 +788,12 @@
             <xs:annotation>
                 <xs:documentation>This defines the default multiselect option background color for this tool. This
                     defaults to the Manifest background-color
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="content:multiselect-option-selected-color">
+            <xs:annotation>
+                <xs:documentation>This defines the default multiselect option-selected-color for this tool.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -120,6 +120,13 @@
                 <xs:restriction base="xs:token">
                     <xs:pattern value="[a-zA-Z0-9_\-]+" />
                     <xs:pattern value="followup:send" />
+                    <xs:pattern value="state:[a-zA-Z][a-zA-Z0-9_]*">
+                        <xs:annotation>
+                            <xs:documentation>State event ids resolve to the value(s) stored in state for the specified
+                                key.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:pattern>
                 </xs:restriction>
             </xs:simpleType>
         </xs:list>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -114,6 +114,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="stateKey">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[a-zA-Z][a-zA-Z0-9_]*" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="eventIdsType">
         <xs:list>
             <xs:simpleType>
@@ -532,6 +538,29 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="multiselect">
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="option">
+                    <xs:complexType>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:group ref="content:elements" />
+                        </xs:choice>
+                        <xs:attribute name="value" type="xs:string" use="required" />
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+            <xs:attribute name="state" type="content:stateKey" use="required" />
+            <xs:attribute name="selection-limit" default="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:int">
+                        <xs:minInclusive value="1" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
     <!-- Link -->
     <xs:complexType name="link">
         <xs:sequence>
@@ -689,6 +718,7 @@
             <xs:element ref="content:animation" />
             <xs:element ref="content:button" />
             <xs:element ref="content:link" />
+            <xs:element ref="content:multiselect" />
             <xs:element ref="content:form" />
             <xs:element ref="content:input" />
             <xs:element ref="content:fallback" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -559,6 +559,10 @@
                 </xs:simpleType>
             </xs:attribute>
         </xs:complexType>
+        <xs:unique name="optionValue">
+            <xs:selector xpath="content:option" />
+            <xs:field xpath="@value" />
+        </xs:unique>
     </xs:element>
 
     <!-- Link -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -538,6 +538,7 @@
         </xs:complexType>
     </xs:element>
 
+    <!-- region multiselect -->
     <xs:element name="multiselect">
         <xs:complexType>
             <xs:choice maxOccurs="unbounded">
@@ -546,6 +547,13 @@
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
                             <xs:group ref="content:elements" />
                         </xs:choice>
+                        <xs:attribute name="background-color" type="content:colorValue">
+                            <xs:annotation>
+                                <xs:documentation>This determines the default background color of Multiselect options.
+                                    This defaults to the option-background-color of the multiselect element.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                         <xs:attribute name="value" type="xs:string" use="required" />
                     </xs:complexType>
                 </xs:element>
@@ -558,12 +566,23 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="option-background-color" type="content:colorValue">
+                <xs:annotation>
+                    <xs:documentation>This determines the default background color of options in this multiselect
+                        element. This defaults to the multiselect-option-background-color defined on the closest
+                        ancestor container.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
         <xs:unique name="optionValue">
             <xs:selector xpath="content:option" />
             <xs:field xpath="@value" />
         </xs:unique>
     </xs:element>
+
+    <xs:attribute name="multiselect-option-background-color" type="content:colorValue" />
+    <!-- endregion multiselect -->
 
     <!-- Link -->
     <xs:complexType name="link">
@@ -707,7 +726,7 @@
     </xs:group>
     <!-- endregion spacer -->
 
-    <!-- Content Elements -->
+    <!-- region Exports -->
     <xs:element name="link" type="content:link" />
     <xs:element name="form" type="content:form" />
     <xs:element name="input" type="content:input" />
@@ -729,4 +748,25 @@
             <xs:group ref="training:contentElements" />
         </xs:choice>
     </xs:group>
+
+    <xs:attributeGroup name="page">
+        <xs:attribute ref="content:multiselect-option-background-color">
+            <xs:annotation>
+                <xs:documentation>This defines the default multiselect option background color for this page. This
+                    attribute defaults to the Manifest multiselect-option-background-color.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="manifest">
+        <xs:attribute ref="content:multiselect-option-background-color">
+            <xs:annotation>
+                <xs:documentation>This defines the default multiselect option background color for this tool. This
+                    defaults to the Manifest background-color
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <!-- endregion Exports -->
 </xs:schema>

--- a/public/xmlns/lesson.xsd
+++ b/public/xmlns/lesson.xsd
@@ -66,6 +66,9 @@
                     <xs:documentation>event_ids that trigger this page</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+
+            <!-- Import any external groups of attributes we want to support -->
+            <xs:attributeGroup ref="content:page" />
         </xs:complexType>
     </xs:element>
 

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -148,6 +148,7 @@
         </xs:attribute>
 
         <!-- Import any external groups of attributes we want to support -->
+        <xs:attributeGroup ref="content:manifest" />
         <xs:attributeGroup ref="lesson:manifest" />
         <xs:attributeGroup ref="tract:manifest" />
     </xs:complexType>

--- a/schema_tests/lesson/invalid/tests/multiselect_duplicate_option_value.xml
+++ b/schema_tests/lesson/invalid/tests/multiselect_duplicate_option_value.xml
@@ -1,0 +1,9 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content>
+        <content:multiselect state="quiz1">
+            <content:option value="answer1" />
+            <content:option value="answer2" />
+            <content:option value="answer1" />
+        </content:multiselect>
+    </content>
+</page>

--- a/schema_tests/lesson/valid/tests/multiselect.xml
+++ b/schema_tests/lesson/valid/tests/multiselect.xml
@@ -1,0 +1,19 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <content>
+        <content:multiselect state="quiz1" selection-limit="1">
+            <content:option value="answer1">
+                <content:text>Answer 1</content:text>
+            </content:option>
+            <content:option value="answer2">
+                <content:text>Answer 2</content:text>
+            </content:option>
+            <content:option value="answer3">
+                <content:text>Answer 3</content:text>
+            </content:option>
+        </content:multiselect>
+
+        <content:button type="event" events="state:quiz1">
+            <content:text>Check Answer</content:text>
+        </content:button>
+    </content>
+</page>


### PR DESCRIPTION
This adds XML support for a Multiselect element, state, and eventId support for utilizing state.

TODO:
- [x] Add background-color attributes for options
- [x] Add Selected color attributes for option backgrounds

Examples:
```xml
<content:multiselect state="quiz1" selection-limit="1">
    <content:option value="answer1" selected-color="rgba(200,255,200,1)">
        <content:text>Answer 1</content:text>
    </content:option>
    <content:option value="answer2">
        <content:text>Answer 2</content:text>
    </content:option>
    <content:option value="answer3" background-color="rgba(255,255,255,1)">
        <content:text>Answer 3</content:text>
    </content:option>
</content:multiselect>
```

```xml
<content:button type="event" event="state:quiz1" />
```