### PR TITLE
GT-1200 Resource language uniqueness

### DIFF
--- a/app/models/language_attribute.rb
+++ b/app/models/language_attribute.rb
@@ -3,5 +3,5 @@
 class LanguageAttribute < BaseAttribute
   belongs_to :language
 
-  validates :resource, presence: true, uniqueness: {scope: [:resource, :key]}
+  validates :resource, presence: true, uniqueness: {scope: [:resource, :language, :key]}
 end

--- a/app/models/language_attribute.rb
+++ b/app/models/language_attribute.rb
@@ -3,5 +3,5 @@
 class LanguageAttribute < BaseAttribute
   belongs_to :language
 
-  validates :resource, presence: true, uniqueness: {scope: [:resource, :language, :key]}
+  validates :resource, presence: true, uniqueness: {scope: [:language, :key]}
 end

--- a/spec/acceptance/resource_languages_controller_spec.rb
+++ b/spec/acceptance/resource_languages_controller_spec.rb
@@ -139,8 +139,6 @@ resource "ResourceLanguage" do
         }
       }
     end
-    let(:language2) { Language.second }
-    let!(:attribute) { FactoryBot.create(:language_attribute, language: language2, resource: resource, key: "enable_tips", value: "false") }
 
     requires_authorization
 

--- a/spec/acceptance/resource_languages_controller_spec.rb
+++ b/spec/acceptance/resource_languages_controller_spec.rb
@@ -139,6 +139,8 @@ resource "ResourceLanguage" do
         }
       }
     end
+    let(:language2) { Language.second }
+    let!(:attribute) { FactoryBot.create(:language_attribute, language: language2, resource: resource, key: "enable_tips", value: "false") }
 
     requires_authorization
 

--- a/spec/models/language_attribute_spec.rb
+++ b/spec/models/language_attribute_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LanguageAttribute, type: :model do
   end
 
   it "key can be reused by multiple languages for a resource" do
-    attr = described_class.create(resource_id: resource.id, language_id: language2.id, key: "enable_tips", value: "false")
+    attr = described_class.new(resource_id: resource.id, language_id: language2.id, key: "enable_tips", value: "false")
 
     expect(attr).to be_valid
   end

--- a/spec/models/language_attribute_spec.rb
+++ b/spec/models/language_attribute_spec.rb
@@ -1,5 +1,21 @@
 require "rails_helper"
 
 RSpec.describe LanguageAttribute, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:resource) { Resource.first }
+  let(:language) { Language.first }
+  let(:language2) { Language.second }
+
+  let!(:attribute) { FactoryBot.create(:language_attribute, language: language, resource: resource, key: "enable_tips", value: "true") }
+
+  it "resource/language/key combination must be unique and is not case sensitive" do
+    attr = described_class.create(resource_id: resource.id, language_id: language.id, key: "enABle_tips", value: "false")
+
+    expect(attr.errors[:resource]).to include "has already been taken"
+  end
+
+  it "key can be reused by multiple languages for a resource" do
+    attr = described_class.create(resource_id: resource.id, language_id: language2.id, key: "enable_tips", value: "false")
+
+    expect(attr).to be_valid
+  end
 end


### PR DESCRIPTION
resource-language attributes should be unique in the context of a `{resource}-{language}-{key}` composite key.

Before this change we couldn't use the same resource-language key on multiple languages for a resource.