### PR TITLE
GT-1235 Add support for defining icons in buttons

### DIFF
--- a/app/lib/package.rb
+++ b/app/lib/package.rb
@@ -6,6 +6,7 @@ class Package
   XPATH_RESOURCES = %w[//@background-image
     //manifest:category/@banner
     //content:animation/@resource
+    //content:button/@icon
     //content:image[not(@restrictTo='web')]/@resource
     //content:text/@start-image
     //content:text/@end-image].freeze

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -574,7 +574,7 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
-                    <xs:attribute name="icon-gravity">
+                    <xs:attribute name="icon-gravity" default="start">
                         <xs:annotation>
                             <xs:documentation>Defines where the icon is rendered in the button</xs:documentation>
                         </xs:annotation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -14,6 +14,32 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="gravity">
+        <xs:annotation>
+            <xs:documentation>This type defines common gravity constants that determine how elements are positioned.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="center" />
+            <xs:enumeration value="start">
+                <xs:annotation>
+                    <xs:documentation>This gravity is left-to-right/right-to-left aware. For left-to-right languages it
+                        resolves to left, for right-to-left languages it resolves to right.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="end">
+                <xs:annotation>
+                    <xs:documentation>This gravity is left-to-right/right-to-left aware. For left-to-right languages it
+                        resolves to right, for right-to-left languages it resolves to left.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="top" />
+            <xs:enumeration value="bottom" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="imageScaleType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="fit">
@@ -42,50 +68,17 @@
     </xs:simpleType>
     <xs:simpleType name="imageGravity">
         <xs:annotation>
-            <xs:documentation>This type defines align attributes for how an image should be aligned before applying the
-                scale type. It is possible to have 1 align type specified for each axis (e.g. "start top").
+            <xs:documentation>This type defines gravity attributes for how an image should be aligned before applying
+                the scale type.
             </xs:documentation>
         </xs:annotation>
-        <xs:list>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="center">
-                        <xs:annotation>
-                            <xs:documentation>The image should be centered in it's container.</xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
-                    <xs:enumeration value="start">
-                        <xs:annotation>
-                            <xs:documentation>The start edge of the image should be aligned to the start edge of the
-                                container. The start edge is the left edge if left to right languages, and right edge in
-                                right to left languages.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
-                    <xs:enumeration value="end">
-                        <xs:annotation>
-                            <xs:documentation>The end edge of the image should be aligned to the end edge of the
-                                container. The end edge is the right edge if left to right languages, and left edge in
-                                right to left languages.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
-                    <xs:enumeration value="top">
-                        <xs:annotation>
-                            <xs:documentation>The top edge of the image should be aligned to the top edge of the
-                                container.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
-                    <xs:enumeration value="bottom">
-                        <xs:annotation>
-                            <xs:documentation>The bottom edge of the image should be aligned to the bottom edge of the
-                                container.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
-                </xs:restriction>
-            </xs:simpleType>
+        <xs:list itemType="content:gravity">
+            <xs:annotation>
+                <xs:documentation>Images edges are pinned to the specified gravity, it is possible to have 1 gravity
+                    type specified for each axis (e.g. "start top" would pin the top left corner of an image to the top
+                    left corner of the container for left-to-right languages).
+                </xs:documentation>
+            </xs:annotation>
         </xs:list>
     </xs:simpleType>
 

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -451,6 +451,7 @@
         </xs:complexType>
     </xs:element>
 
+    <!-- region button -->
     <xs:element name="button">
         <xs:complexType>
             <xs:complexContent>
@@ -554,11 +555,44 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+
+                    <!-- region Icon Attributes -->
+                    <xs:attribute name="icon" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>Defines an image to display as an icon in this button.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="icon-size" default="18">
+                        <xs:annotation>
+                            <xs:documentation>Defines the size in "density-independent pixels"/"points" of the icon.
+                                This defaults to 18.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:int">
+                                <xs:minInclusive value="1" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="icon-gravity">
+                        <xs:annotation>
+                            <xs:documentation>Defines where the icon is rendered in the button</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="content:gravity">
+                                <xs:enumeration value="start" />
+                                <xs:enumeration value="end" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <!-- endregion Icon Attributes -->
+
                     <xs:attributeGroup ref="content:baseAttributes" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+    <!-- endregion button -->
 
     <!-- region multiselect -->
     <xs:element name="multiselect">


### PR DESCRIPTION
This allows an icon to be defined for a button which will be rendered inside the button.

Example:
```xml
<content:button type="url" icon="globe.png" icon-size="18" icon-gravity="end">
  <content:text>Website</content:text>
</content:button>
```