### PR TITLE
GT-980 Standardize "clickable" elements within the content spec

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -499,124 +499,122 @@
                     </xs:annotation>
                 </xs:element>
             </xs:all>
-                    <xs:attribute name="type" use="required">
-                        <xs:annotation>
-                            <xs:documentation>This attribute determines what type of button this is. Unrecognized button
-                                types should be treated as unsupported by the renderer.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="event">
-                                    <xs:annotation>
-                                        <xs:documentation>"event" type buttons will trigger the events specified.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:enumeration>
-                                <xs:enumeration value="url">
-                                    <xs:annotation>
-                                        <xs:documentation>"url" type buttons will launch the url specified.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:enumeration>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="events" type="content:eventIdsType" use="optional">
-                        <xs:annotation>
-                            <xs:documentation>This attribute defines the events to trigger for "event" buttons.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="url" type="content:uri" use="optional">
-                        <xs:annotation>
-                            <xs:documentation>This attribute defines the url to open for "url" buttons.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="url-i18n-id" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation>This attribute defines a OneSky phrase id that contains the url for this
-                                button.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="style" default="contained">
-                        <xs:annotation>
-                            <xs:documentation>This attribute defines the style of the button. It defaults to "contained"
-                                unless otherwise specified.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="contained">
-                                    <xs:annotation>
-                                        <xs:documentation>This is a solid color button. The button color defines the
-                                            solid color for this button. The button text-color defaults to the
-                                            primary-text-color of the closest styles ancestor.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:enumeration>
-                                <xs:enumeration value="outlined">
-                                    <xs:annotation>
-                                        <xs:documentation>This is an outlined button. The button color defines the
-                                            outline color for this button. The button text-color defaults to the
-                                            color of this button.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:enumeration>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="color" type="content:colorValue" use="optional">
-                        <xs:annotation>
-                            <xs:documentation>This attribute determines the color of the button. This defaults to the
-                                button-color of the closest ancestor element. If button-color is not defined in the
-                                element hierarchy the color then defaults to the primary-color of the closest ancestor
-                                element.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="background-color" type="content:colorValue" default="rgba(0,0,0,0)">
-                        <xs:annotation>
-                            <xs:documentation>This attribute determines the background color of outlined buttons. This
-                                defaults to rgba(0,0,0,0).
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
+            <xs:attribute name="type" use="required">
+                <xs:annotation>
+                    <xs:documentation>This attribute determines what type of button this is. Unrecognized button
+                        types should be treated as unsupported by the renderer.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="event">
+                            <xs:annotation>
+                                <xs:documentation>"event" type buttons will trigger the events specified.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="url">
+                            <xs:annotation>
+                                <xs:documentation>"url" type buttons will launch the url specified.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="events" type="content:eventIdsType" use="optional">
+                <xs:annotation>
+                    <xs:documentation>This attribute defines the events to trigger for "event" buttons.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="url" type="content:uri" use="optional">
+                <xs:annotation>
+                    <xs:documentation>This attribute defines the url to open for "url" buttons.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="url-i18n-id" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>This attribute defines a OneSky phrase id that contains the url for this
+                        button.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="style" default="contained">
+                <xs:annotation>
+                    <xs:documentation>This attribute defines the style of the button. It defaults to "contained" unless
+                        otherwise specified.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="contained">
+                            <xs:annotation>
+                                <xs:documentation>This is a solid color button. The button color defines the solid color
+                                    for this button. The button text-color defaults to the primary-text-color of the
+                                    closest styles ancestor.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="outlined">
+                            <xs:annotation>
+                                <xs:documentation>This is an outlined button. The button color defines the outline color
+                                    for this button. The button text-color defaults to the color of this button.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="color" type="content:colorValue" use="optional">
+                <xs:annotation>
+                    <xs:documentation>This attribute determines the color of the button. This defaults to the
+                        button-color of the closest ancestor element. If button-color is not defined in the
+                        element hierarchy the color then defaults to the primary-color of the closest ancestor
+                        element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="background-color" type="content:colorValue" default="rgba(0,0,0,0)">
+                <xs:annotation>
+                    <xs:documentation>This attribute determines the background color of outlined buttons. This
+                        defaults to rgba(0,0,0,0).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
 
-                    <!-- region Icon Attributes -->
-                    <xs:attribute name="icon" type="xs:string">
-                        <xs:annotation>
-                            <xs:documentation>Defines an image to display as an icon in this button.</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="icon-size" default="18">
-                        <xs:annotation>
-                            <xs:documentation>Defines the size in "density-independent pixels"/"points" of the icon.
-                                This defaults to 18.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:int">
-                                <xs:minInclusive value="1" />
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="icon-gravity" default="start">
-                        <xs:annotation>
-                            <xs:documentation>Defines where the icon is rendered in the button</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="content:gravity">
-                                <xs:enumeration value="start" />
-                                <xs:enumeration value="end" />
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <!-- endregion Icon Attributes -->
+            <!-- region Icon Attributes -->
+            <xs:attribute name="icon" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Defines an image to display as an icon in this button.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="icon-size" default="18">
+                <xs:annotation>
+                    <xs:documentation>Defines the size in "density-independent pixels"/"points" of the icon. This
+                        defaults to 18.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:int">
+                        <xs:minInclusive value="1" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="icon-gravity" default="start">
+                <xs:annotation>
+                    <xs:documentation>Defines where the icon is rendered in the button</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="content:gravity">
+                        <xs:enumeration value="start" />
+                        <xs:enumeration value="end" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <!-- endregion Icon Attributes -->
 
-                    <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="content:baseAttributes" />
         </xs:complexType>
     </xs:element>
     <!-- endregion button -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -256,6 +256,28 @@
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
+
+    <xs:attributeGroup name="clickableElement">
+        <xs:attribute name="events" type="content:eventIdsType">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the events to trigger when clicking on this element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="content:uri">
+            <xs:annotation>
+                <xs:documentation>This attribute defines the url to open when clicking on this element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url-i18n-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>This attribute defines a OneSky phrase id that contains the url for this
+                    element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
     <!-- endregion Common Attributes -->
 
     <!-- element nodes -->
@@ -522,24 +544,6 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
-            <xs:attribute name="events" type="content:eventIdsType" use="optional">
-                <xs:annotation>
-                    <xs:documentation>This attribute defines the events to trigger for "event" buttons.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="url" type="content:uri" use="optional">
-                <xs:annotation>
-                    <xs:documentation>This attribute defines the url to open for "url" buttons.</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="url-i18n-id" type="xs:string" use="optional">
-                <xs:annotation>
-                    <xs:documentation>This attribute defines a OneSky phrase id that contains the url for this
-                        button.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
             <xs:attribute name="style" default="contained">
                 <xs:annotation>
                     <xs:documentation>This attribute defines the style of the button. It defaults to "contained" unless
@@ -615,6 +619,7 @@
             <!-- endregion Icon Attributes -->
 
             <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="content:clickableElement" />
         </xs:complexType>
     </xs:element>
     <!-- endregion button -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -705,27 +705,32 @@
     <xs:attribute name="multiselect-option-selected-color" type="content:colorValue" />
     <!-- endregion multiselect -->
 
-    <!-- Link -->
-    <xs:complexType name="link">
-        <xs:all>
-            <xs:element ref="analytics:events" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation>
-                        Define any analytics events that are triggered by this link. The default trigger mode
-                        for analytics events on links is "clicked".
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="text" type="content:textType">
-                <xs:annotation>
-                    <xs:documentation>This is the text content of this link. The text-color attribute defaults to the
-                        primary-color of the closest ancestor container.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:all>
-        <xs:attributeGroup ref="content:clickableElement" />
-    </xs:complexType>
+    <!-- region Link -->
+    <xs:element name="link">
+        <xs:complexType>
+            <xs:all>
+                <xs:element ref="analytics:events" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Define any analytics events that are triggered by this link. The default trigger mode for
+                            analytics events on links is "clicked".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="text" type="content:textType">
+                    <xs:annotation>
+                        <xs:documentation>This is the text content of this link. The text-color attribute defaults to
+                            the primary-color of the closest ancestor container.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:all>
+
+            <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="content:clickableElement" />
+        </xs:complexType>
+    </xs:element>
+    <!-- endregion Link -->
 
     <!--
         Form Content - vertical stacked content with input fields
@@ -847,7 +852,6 @@
     <!-- endregion spacer -->
 
     <!-- region Exports -->
-    <xs:element name="link" type="content:link" />
     <xs:element name="form" type="content:form" />
     <xs:element name="input" type="content:input" />
     <xs:group name="elements">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -483,22 +483,22 @@
     <!-- region button -->
     <xs:element name="button">
         <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="content:textChild">
+            <xs:all>
+                <xs:element ref="analytics:events" minOccurs="0">
                     <xs:annotation>
-                        <xs:documentation>The content:text child element is the text content of this button. The
-                            text-align attribute for buttons defaults to center.
+                        <xs:documentation>Define any analytics events that are triggered by this button. The default
+                            trigger mode for analytics events on buttons is "clicked".
                         </xs:documentation>
                     </xs:annotation>
-                    <xs:sequence>
-                        <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation>Define any analytics events that are triggered by this button. The
-                                    default trigger mode for analytics events on buttons is "clicked".
-                                </xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:sequence>
+                </xs:element>
+                <xs:element name="text" type="content:textType">
+                    <xs:annotation>
+                        <xs:documentation>This is the text content of this button. The text-align attribute for buttons
+                            defaults to center.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:all>
                     <xs:attribute name="type" use="required">
                         <xs:annotation>
                             <xs:documentation>This attribute determines what type of button this is. Unrecognized button
@@ -617,8 +617,6 @@
                     <!-- endregion Icon Attributes -->
 
                     <xs:attributeGroup ref="content:baseAttributes" />
-                </xs:extension>
-            </xs:complexContent>
         </xs:complexType>
     </xs:element>
     <!-- endregion button -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -707,15 +707,8 @@
 
     <!-- Link -->
     <xs:complexType name="link">
-        <xs:sequence>
-            <xs:element ref="content:text">
-                <xs:annotation>
-                    <xs:documentation>This element is the text content of this link. The text-color attribute defaults
-                        to the primary-color of the closest ancestor container.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element ref="analytics:events" minOccurs="0" maxOccurs="1">
+        <xs:all>
+            <xs:element ref="analytics:events" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Define any analytics events that are triggered by this link. The default trigger mode
@@ -723,9 +716,15 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-        </xs:sequence>
-        <!-- events: events to fire when link is pressed. -->
-        <xs:attribute name="events" type="content:eventIdsType" use="required" />
+            <xs:element name="text" type="content:textType">
+                <xs:annotation>
+                    <xs:documentation>This is the text content of this link. The text-color attribute defaults to the
+                        primary-color of the closest ancestor container.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attributeGroup ref="content:clickableElement" />
     </xs:complexType>
 
     <!--

--- a/schema_tests/tract/invalid/tests/button_missing_text.xml
+++ b/schema_tests/tract/invalid/tests/button_missing_text.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:button type="url" url="https://www.google.com/" />
+        </content:paragraph>
+    </hero>
+</page>

--- a/schema_tests/tract/valid/tests/button_analytics.xml
+++ b/schema_tests/tract/valid/tests/button_analytics.xml
@@ -10,6 +10,12 @@
                     <analytics:event action="test" system="firebase" />
                 </analytics:events>
             </content:button>
+            <content:button type="url" url="https://www.google.com/">
+                <analytics:events>
+                    <analytics:event action="test" system="firebase" />
+                </analytics:events>
+                <content:text>text</content:text>
+            </content:button>
         </content:paragraph>
     </hero>
 </page>

--- a/schema_tests/tract/valid/tests/links.xml
+++ b/schema_tests/tract/valid/tests/links.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:link url="https://www.google.com/">
+                <content:text>text</content:text>
+            </content:link>
+            <content:link events="followup:send">
+                <analytics:events>
+                    <analytics:event action="test" system="firebase" />
+                </analytics:events>
+                <content:text>text</content:text>
+            </content:link>
+            <content:link events="followup:send">
+                <content:text>text</content:text>
+                <analytics:events>
+                    <analytics:event action="test" system="firebase" />
+                </analytics:events>
+            </content:link>
+        </content:paragraph>
+    </hero>
+</page>


### PR DESCRIPTION
This is mostly code cleanup to make the spec a little more robust & flexible.

Functional changes:
- Allow analytics events to be defined before the text in buttons and links
- Add url attributes to link content element to make it possible to open urls from links
- Add base attributes (`restrictTo`, `version`, `required-features`) to link element
- Tighten up attributes allowed on the `content:text` child of a link. It's no longer possible to set start/end images on this element.