### PR TITLE
Content Spec cleanup

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -99,15 +99,16 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="textStyle">
-        <xs:restriction base="xs:token">
-            <xs:enumeration value="bold" />
-            <xs:enumeration value="italic" />
-            <xs:enumeration value="underline" />
-        </xs:restriction>
-    </xs:simpleType>
     <xs:simpleType name="textStyles">
-        <xs:list itemType="content:textStyle" />
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="bold" />
+                    <xs:enumeration value="italic" />
+                    <xs:enumeration value="underline" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
     </xs:simpleType>
 
     <xs:simpleType name="uri">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -139,13 +139,14 @@
             </xs:simpleType>
         </xs:list>
     </xs:simpleType>
-    <xs:simpleType name="listener">
-        <xs:restriction base="xs:token">
-            <xs:pattern value="[a-zA-Z0-9_\-]+" />
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="listenersType">
-        <xs:list itemType="content:listener" />
+    <xs:simpleType name="listeners">
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:pattern value="[a-zA-Z0-9_\-]+" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
     </xs:simpleType>
 
     <xs:simpleType name="deviceType">
@@ -322,7 +323,7 @@
                                 <xs:group ref="content:fixedSpacerOnly" />
                             </xs:choice>
                         </xs:sequence>
-                        <xs:attribute name="listeners" type="content:listenersType">
+                        <xs:attribute name="listeners" type="content:listeners">
                             <xs:annotation>
                                 <xs:documentation>event_ids that trigger this tab</xs:documentation>
                             </xs:annotation>
@@ -489,12 +490,12 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="play-listeners" type="content:listenersType">
+            <xs:attribute name="play-listeners" type="content:listeners">
                 <xs:annotation>
                     <xs:documentation>event_ids that trigger playback of this animation.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="stop-listeners" type="content:listenersType">
+            <xs:attribute name="stop-listeners" type="content:listeners">
                 <xs:annotation>
                     <xs:documentation>event_ids that will stop playback of this animation.</xs:documentation>
                 </xs:annotation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -122,7 +122,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="eventIdsType">
+    <xs:simpleType name="events">
         <xs:list>
             <xs:simpleType>
                 <xs:restriction base="xs:token">
@@ -259,7 +259,7 @@
     </xs:attributeGroup>
 
     <xs:attributeGroup name="clickableElement">
-        <xs:attribute name="events" type="content:eventIdsType">
+        <xs:attribute name="events" type="content:events">
             <xs:annotation>
                 <xs:documentation>This attribute defines the events to trigger when clicking on this element.
                 </xs:documentation>
@@ -446,7 +446,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:attribute name="resource" type="xs:string" use="required" />
-            <xs:attribute name="events" type="content:eventIdsType">
+            <xs:attribute name="events" type="content:events">
                 <xs:annotation>
                     <xs:documentation>This attribute defines the events to trigger when the user "clicks" the image.
                     </xs:documentation>
@@ -484,7 +484,7 @@
             <xs:attribute name="resource" type="xs:string" use="required" />
             <xs:attribute name="autoplay" type="xs:boolean" default="true" />
             <xs:attribute name="loop" type="xs:boolean" default="true" />
-            <xs:attribute name="events" type="content:eventIdsType">
+            <xs:attribute name="events" type="content:events">
                 <xs:annotation>
                     <xs:documentation>This attribute defines the events to trigger when the user "clicks" the animation.
                     </xs:documentation>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -150,35 +150,36 @@
         </xs:list>
     </xs:simpleType>
 
-    <xs:simpleType name="deviceType">
-        <xs:restriction base="xs:token">
-            <xs:enumeration value="mobile">
-                <xs:annotation>
-                    <xs:documentation>This device type represents a native app on Android or iOS</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="android">
-                <xs:annotation>
-                    <xs:documentation>This device type represents a native app on Android</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="ios">
-                <xs:annotation>
-                    <xs:documentation>This device type represents a native app on iOS</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="web">
-                <xs:annotation>
-                    <xs:documentation>This device type represents a web browser</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:simpleType name="deviceTypes">
         <xs:annotation>
             <xs:documentation>A space separated list of device types</xs:documentation>
         </xs:annotation>
-        <xs:list itemType="content:deviceType" />
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="mobile">
+                        <xs:annotation>
+                            <xs:documentation>This device type represents a native app on Android or iOS</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="android">
+                        <xs:annotation>
+                            <xs:documentation>This device type represents a native app on Android</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="ios">
+                        <xs:annotation>
+                            <xs:documentation>This device type represents a native app on iOS</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="web">
+                        <xs:annotation>
+                            <xs:documentation>This device type represents a web browser</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
     </xs:simpleType>
 
     <xs:simpleType name="feature">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -182,25 +182,26 @@
         </xs:list>
     </xs:simpleType>
 
-    <xs:simpleType name="feature">
-        <xs:restriction base="xs:token">
-            <xs:enumeration value="animation">
-                <xs:annotation>
-                    <xs:documentation>The animation content element feature</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="multiselect">
-                <xs:annotation>
-                    <xs:documentation>The multiselect content element feature</xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:simpleType name="features">
         <xs:annotation>
             <xs:documentation>A space separated list of features</xs:documentation>
         </xs:annotation>
-        <xs:list itemType="content:feature" />
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="animation">
+                        <xs:annotation>
+                            <xs:documentation>The animation content element feature</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="multiselect">
+                        <xs:annotation>
+                            <xs:documentation>The multiselect content element feature</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
     </xs:simpleType>
     <!-- endregion Value Definitions -->
 

--- a/public/xmlns/lesson.xsd
+++ b/public/xmlns/lesson.xsd
@@ -72,7 +72,7 @@
                     <xs:documentation>Is this page hidden until triggered by a listener.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="listeners" type="content:listenersType">
+            <xs:attribute name="listeners" type="content:listeners">
                 <xs:annotation>
                     <xs:documentation>event_ids that trigger this page</xs:documentation>
                 </xs:annotation>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -141,7 +141,7 @@
             </xs:annotation>
         </xs:attribute>
 
-        <xs:attribute name="dismiss-listeners" type="content:listenersType">
+        <xs:attribute name="dismiss-listeners" type="content:listeners">
             <xs:annotation>
                 <xs:documentation>This attribute defines events that will dismiss this tool.</xs:documentation>
             </xs:annotation>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -94,7 +94,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="listeners" type="content:listenersType" use="optional">
+        <xs:attribute name="listeners" type="content:listeners" use="optional">
             <xs:annotation>
                 <xs:documentation>event_ids that trigger this page</xs:documentation>
             </xs:annotation>
@@ -225,13 +225,13 @@
 
         <!-- hidden: DEFAULT( false ) whether this card is hidden. hidden cards can still be displayed if they have a listener that is triggered. -->
         <xs:attribute name="hidden" type="xs:boolean" use="optional" />
-        <xs:attribute name="listeners" type="content:listenersType" use="optional">
+        <xs:attribute name="listeners" type="content:listeners" use="optional">
             <xs:annotation>
                 <xs:documentation>This attribute defines events that will trigger display of this card.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="dismiss-listeners" type="content:listenersType" use="optional">
+        <xs:attribute name="dismiss-listeners" type="content:listeners" use="optional">
             <xs:annotation>
                 <xs:documentation>This attribute defines events that will dismiss this card.</xs:documentation>
             </xs:annotation>
@@ -292,8 +292,8 @@
                 <xs:element ref="content:paragraph" />
             </xs:choice>
         </xs:sequence>
-        <xs:attribute name="listeners" type="content:listenersType" use="required" />
-        <xs:attribute name="dismiss-listeners" type="content:listenersType" use="required" />
+        <xs:attribute name="listeners" type="content:listeners" use="required" />
+        <xs:attribute name="dismiss-listeners" type="content:listeners" use="required" />
         <xs:attribute name="text-scale" type="xs:float" default="1">
             <xs:annotation>
                 <xs:documentation>Defines how much to scale all the text content in this modal by.</xs:documentation>

--- a/public/xmlns/tract.xsd
+++ b/public/xmlns/tract.xsd
@@ -242,7 +242,7 @@
     <xs:complexType name="callToAction">
         <xs:complexContent>
             <xs:extension base="content:textChild">
-                <xs:attribute name="events" type="content:eventIdsType" use="optional">
+                <xs:attribute name="events" type="content:events" use="optional">
                     <xs:annotation>
                         <xs:documentation>Event ids to trigger when the call to action arrow is pressed. Default
                             behavior is to advance to the next page.


### PR DESCRIPTION
- simplify listeners type
- rename content:events type
- consolidate textStyles attribute
- consolidate the deviceTypes type
- consolidate the features type
