### PR TITLE
GT-1339 Make Animations and Images "clickable"

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -483,12 +483,6 @@
             <xs:attribute name="resource" type="xs:string" use="required" />
             <xs:attribute name="autoplay" type="xs:boolean" default="true" />
             <xs:attribute name="loop" type="xs:boolean" default="true" />
-            <xs:attribute name="events" type="content:events">
-                <xs:annotation>
-                    <xs:documentation>This attribute defines the events to trigger when the user "clicks" the animation.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
             <xs:attribute name="play-listeners" type="content:listeners">
                 <xs:annotation>
                     <xs:documentation>event_ids that trigger playback of this animation.</xs:documentation>
@@ -499,6 +493,9 @@
                     <xs:documentation>event_ids that will stop playback of this animation.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+
+            <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="content:clickableElement" />
         </xs:complexType>
     </xs:element>
 

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -449,13 +449,9 @@
         </xs:annotation>
         <xs:complexType>
             <xs:attribute name="resource" type="xs:string" use="required" />
-            <xs:attribute name="events" type="content:events">
-                <xs:annotation>
-                    <xs:documentation>This attribute defines the events to trigger when the user "clicks" the image.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
+
             <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="content:clickableElement" />
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
Use the clickable attributeGroup on Images and Animations for consistency. This same attributeGroup will be used by content Cards