### PR TITLE
GT-1291 Support setting pixel width for images

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -565,6 +565,15 @@
         </xs:annotation>
         <xs:complexType>
             <xs:attribute name="resource" type="xs:string" use="required" />
+            <xs:attribute name="width" default="100%">
+                <xs:simpleType>
+                    <xs:restriction base="content:dimension">
+                        <xs:pattern value="[1-9][0-9]*" />
+                        <xs:pattern value="100%" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="gravity" type="content:horizontalGravity" default="center" />
 
             <xs:attributeGroup ref="content:baseAttributes" />
             <xs:attributeGroup ref="content:clickableElement" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -707,6 +707,15 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="width" default="100%">
+                <xs:simpleType>
+                    <xs:restriction base="content:dimension">
+                        <xs:pattern value="[1-9][0-9]*" />
+                        <xs:pattern value="100%" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="gravity" type="content:horizontalGravity" default="center" />
 
             <!-- region Icon Attributes -->
             <xs:attribute name="icon" type="xs:string">


### PR DESCRIPTION
Support defining a pixel width and horizontal gravity for images and buttons.

Examples:
```xml
<content:button url="https://example.com" width="150" gravity="end">
  <content:text>Button</content:text>
</content:button>
```
```xml
<content:image resource="image.png" width="64" gravity="center" />
```