### PR TITLE
GT-1294 Support parent attribute on cyoa pages

### DIFF
--- a/public/xmlns/cyoa.xsd
+++ b/public/xmlns/cyoa.xsd
@@ -1,9 +1,17 @@
 <!-- Choose Your Own Adventure -->
-<xs:schema xmlns:page="https://mobile-content-api.cru.org/xmlns/page" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/page">
+<xs:schema xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa" xmlns:page="https://mobile-content-api.cru.org/xmlns/page" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/cyoa">
 
-    <xs:include schemaLocation="page_content.xsd" />
-    <xs:include schemaLocation="page_cardcollection.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/page" schemaLocation="cyoa_pages.xsd" />
 
-    <xs:element name="page" type="page:BasePageType" />
+    <xs:attribute name="parent" type="page:id" />
+
+    <xs:attributeGroup name="page">
+        <xs:attribute ref="cyoa:parent">
+            <xs:annotation>
+                <xs:documentation>This defines the parent of this page in a cyoa tool. This defaults to no parent page.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
 </xs:schema>

--- a/public/xmlns/cyoa_pages.xsd
+++ b/public/xmlns/cyoa_pages.xsd
@@ -1,0 +1,9 @@
+<!-- Choose Your Own Adventure Supported Page Types -->
+<xs:schema xmlns:page="https://mobile-content-api.cru.org/xmlns/page" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/page">
+
+    <xs:include schemaLocation="page_content.xsd" />
+    <xs:include schemaLocation="page_cardcollection.xsd" />
+
+    <xs:element name="page" type="page:BasePageType" />
+</xs:schema>

--- a/public/xmlns/page.xsd
+++ b/public/xmlns/page.xsd
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
     xmlns:page="https://mobile-content-api.cru.org/xmlns/page" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/page">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/cyoa" schemaLocation="cyoa.xsd" />
 
     <!-- region Page -->
     <xs:simpleType name="id">
@@ -106,6 +108,7 @@
 
         <!-- Import any external groups of attributes we want to support -->
         <xs:attributeGroup ref="content:page" />
+        <xs:attributeGroup ref="cyoa:page" />
     </xs:complexType>
     <!-- region Page -->
 

--- a/public/xmlns/page.xsd
+++ b/public/xmlns/page.xsd
@@ -8,6 +8,15 @@
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
 
     <!-- region Page -->
+    <xs:simpleType name="id">
+        <xs:annotation>
+            <xs:documentation>Page id type</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[a-zA-Z_\-.]+" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="BasePageType">
         <xs:sequence>
             <xs:element ref="analytics:events" minOccurs="0">
@@ -20,7 +29,7 @@
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="id" />
+        <xs:attribute name="id" type="page:id" />
 
         <xs:attribute name="hidden" type="xs:boolean" default="false">
             <xs:annotation>

--- a/schema_tests/cyoa/valid/convostarter/categories.xml
+++ b/schema_tests/cyoa/valid/convostarter/categories.xml
@@ -1,0 +1,30 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content"
+    id="categories" listeners="categories">
+    <content>
+        <content:paragraph>
+            <content:text text-scale="1.333">Choose a category and discover interesting, fun and powerful questions to
+                ask in your next conversation.
+            </content:text>
+        </content:paragraph>
+        <content:flow item-width="50%" row-gravity="start">
+            <content:card events="category_culture">
+                <content:image resource="category_culture.png" />
+                <content:spacer height="12" mode="fixed" />
+                <content:text minimum-lines="2" text-align="center" text-style="bold">Culture and worldview
+                </content:text>
+            </content:card>
+            <content:card>
+                <content:image resource="category_family.png" />
+                <content:spacer height="12" mode="fixed" />
+                <content:text minimum-lines="2" text-align="center" text-style="bold">Family</content:text>
+            </content:card>
+            <content:card>
+                <content:image resource="category_spirituality.png" />
+                <content:spacer height="12" mode="fixed" />
+                <content:text minimum-lines="2" text-align="center" text-style="bold">Spirituality</content:text>
+            </content:card>
+        </content:flow>
+    </content>
+</page>

--- a/schema_tests/cyoa/valid/convostarter/category_culture.xml
+++ b/schema_tests/cyoa/valid/convostarter/category_culture.xml
@@ -1,6 +1,8 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/page"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="cardcollection"
+    cyoa:parent="categories"
     background-color="rgba(245,245,245,1)" listeners="category_culture" text-scale="1.555">
     <cards>
         <card id="1">

--- a/schema_tests/cyoa/valid/convostarter/category_culture.xml
+++ b/schema_tests/cyoa/valid/convostarter/category_culture.xml
@@ -1,0 +1,39 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="cardcollection"
+    background-color="rgba(245,245,245,1)" listeners="category_culture" text-scale="1.555">
+    <cards>
+        <card id="1">
+            <content>
+                <content:text text-scale="0.5">Culture &amp; worldview</content:text>
+                <content:text>What's your favorite thing to do where you live?</content:text>
+            </content>
+        </card>
+        <card id="2">
+            <content>
+                <content:text text-scale="0.5">Culture &amp; worldview</content:text>
+                <content:text>What did you believe as a child that seems ridiculous to you now?</content:text>
+            </content>
+        </card>
+        <card id="3">
+            <content>
+                <content:text text-scale="0.5">Culture &amp; worldview</content:text>
+                <content:text>In what area or way do you feel most misunderstood?</content:text>
+            </content>
+        </card>
+        <card id="4">
+            <content>
+                <content:text text-scale="0.5">Culture &amp; worldview</content:text>
+                <content:text>Would you change the way you were raised in any way, and if so, how?</content:text>
+            </content>
+        </card>
+        <card id="5">
+            <content>
+                <content:text text-scale="0.5">Culture &amp; worldview</content:text>
+                <content:text>People say that money by itself cannot buy happiness; what do you think leads to a happy
+                    life?
+                </content:text>
+            </content>
+        </card>
+    </cards>
+</page>

--- a/schema_tests/cyoa/valid/convostarter/intro.xml
+++ b/schema_tests/cyoa/valid/convostarter/intro.xml
@@ -1,0 +1,31 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content"
+    background-color="rgba(59,164,219,1)" text-color="rgba(255,255,255,1)">
+    <content>
+        <content:spacer height="40" mode="fixed" />
+        <content:paragraph>
+            <content:text>Starting a conversation sounds simple - just talk about the weather or a TV show you’re
+                enjoying.
+            </content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text>Being intentional about having deeper conversations, and talking about spiritual things, feels
+                different.
+            </content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text>Being intentional about having deeper conversations, and talking about spiritual things, feels
+                different.
+            </content:text>
+        </content:paragraph>
+        <content:paragraph>
+            <content:text text-scale="0.8" text-style="bold">Using our conversation starters can help you feel ready to
+                talk with anyone.
+            </content:text>
+        </content:paragraph>
+        <content:button type="event" color="rgba(255,255,255,1)" events="categories">
+            <content:text text-color="rgba(59,164,219,1)">Let's do it</content:text>
+        </content:button>
+    </content>
+</page>


### PR DESCRIPTION
- add some current cyoa pages for schema tests
- define a page:id type
- add a cyoa:parent attribute that defines a parent page for the current page
