### PR TITLE
restrict valid characters for user counter names

### DIFF
--- a/app/models/user_counter.rb
+++ b/app/models/user_counter.rb
@@ -4,7 +4,7 @@ class UserCounter < ApplicationRecord
   DECAY_RATE = -0.0077
 
   belongs_to :user
-  validates :counter_name, format: {with: /\A[a-zA-Z0-9_\-.]+\z/, message: "has invalid characters"}
+  validates :counter_name, format: {with: /\A[-_.a-zA-Z0-9]+\z/, message: "has invalid characters"}
 
   def decay
     date_now = Date.today

--- a/app/models/user_counter.rb
+++ b/app/models/user_counter.rb
@@ -4,6 +4,7 @@ class UserCounter < ApplicationRecord
   DECAY_RATE = -0.0077
 
   belongs_to :user
+  validates :counter_name, format: {with: /\A[a-zA-Z0-9_\-.]+\z/, message: "has invalid characters"}
 
   def decay
     date_now = Date.today

--- a/spec/models/user_counter_spec.rb
+++ b/spec/models/user_counter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserCounter do
+  let(:name_invalid) { "invalid:name" }
+
+  let(:user) { FactoryBot.create(:user) }
+
+  it "cannot use invalid counter name" do
+    result = described_class.create(user: user, counter_name: name_invalid)
+
+    expect(result.errors["counter_name"]).to include("has invalid characters")
+  end
+end


### PR DESCRIPTION
This adds a validation to user counter names to reject any names that don't use URI safe characters