### PR TITLE
fix potential duplicate attributes on translation substitutions

### DIFF
--- a/app/models/xml/translatable.rb
+++ b/app/models/xml/translatable.rb
@@ -38,8 +38,7 @@ module Xml
         translated_phrase = phrases[phrase_id]
 
         if translated_phrase.present?
-          attribute.name = new_name
-          attribute.value = translated_phrase
+          attribute.parent.set_attribute(new_name, translated_phrase)
         elsif strict
           raise Error::TextNotFoundError, "Translated phrase not found: ID: #{phrase_id}, base text: #{attribute.value}"
         end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,7 @@ page_13_structure = '<?xml version="1.0" encoding="UTF-8" ?>
       <content:text>These four points explain how to enter into a personal relationship with God and
         experience the life for which you were created.
       </content:text>
-      <content:button type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">
+      <content:button url="https://url.com" type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">
         <content:text>Label</content:text>
       </content:button>
     </content:form>

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -237,7 +237,7 @@ describe Translation do
 
   def includes_translated_attributes
     # check that the url attribute is not duplicated
-    expect(result).to_not include %|<content:button url="https://url.com" type="url" url="https://www.bible.com/">|
-    expect(result).to include %|<content:button url="#{phrase_three}" type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">|
+    expect(result).to_not include %(<content:button url="https://url.com" type="url" url="https://www.bible.com/">)
+    expect(result).to include %(<content:button url="#{phrase_three}" type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">)
   end
 end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -236,6 +236,8 @@ describe Translation do
   end
 
   def includes_translated_attributes
-    expect(result).to include phrase_three
+    # check that the url attribute is not duplicated
+    expect(result).to_not include %|<content:button url="https://url.com" type="url" url="https://www.bible.com/">|
+    expect(result).to include %|<content:button url="#{phrase_three}" type="url" url-i18n-id="9deda19f-c3ee-42ed-a1eb-92423e543353">|
   end
 end


### PR DESCRIPTION
set the parent element's child element instead of simply updating the
url-i18n-id element