### PR TITLE
GT-1776 move the user counters API to /user/me/counters

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,11 @@ Rails.application.routes.draw do
   resources :custom_manifests, only: [:create, :update, :destroy, :show]
 
   scope "user" do
-    resources :counters, controller: "user_counters", only: [:index, :update]
+    resources :counters, controller: "user_counters", only: [:update] # Legacy route for GodTools Android v5.7.0-v6.0.0
+
+    scope "me" do
+      resources :counters, controller: "user_counters", only: [:index, :update]
+    end
   end
 
   get "monitors/lb"

--- a/spec/acceptance/user_counters_controller_spec.rb
+++ b/spec/acceptance/user_counters_controller_spec.rb
@@ -13,7 +13,7 @@ resource "UserCounters" do
 
   let(:structure) { FactoryBot.attributes_for(:user_counter)[:structure] }
 
-  patch "user/counters/:id" do
+  patch "user/me/counters/:id" do
     let(:id) { "tool_opens.kgp" }
     let(:user) { FactoryBot.create(:user) }
     requires_okta_login
@@ -59,7 +59,7 @@ resource "UserCounters" do
     end
   end
 
-  get "user/counters" do
+  get "user/me/counters" do
     let(:user) { FactoryBot.create(:user) }
     let!(:user_counter) { FactoryBot.create(:user_counter, user: user, counter_name: "tool_opens.kgp", count: 50, decayed_count: 50, last_decay: 90.days.ago) }
     let!(:user_counter2) { FactoryBot.create(:user_counter, user: user, counter_name: "other.kgp", count: 60, decayed_count: 40, last_decay: 90.days.ago) }

--- a/spec/acceptance/user_counters_controller_spec.rb
+++ b/spec/acceptance/user_counters_controller_spec.rb
@@ -74,4 +74,50 @@ resource "UserCounters" do
       expect(response_body).to eq(expected_result)
     end
   end
+
+  patch "user/counters/:id" do
+    let(:id) { "tool_opens.kgp" }
+    let(:user) { FactoryBot.create(:user) }
+    requires_okta_login
+
+    it "create user_counter" do
+      expect {
+        do_request data: {type: "user_counter", attributes: {increment: 20}}
+      }.to change { UserCounter.count }.by(1)
+
+      expect(status).to eq(200)
+      json_response = JSON.parse(response_body)["data"]
+      expect(json_response).not_to be_nil
+      expect(json_response["id"]).to eq("tool_opens.kgp")
+      expect(json_response["attributes"]["count"]).to eq(20)
+      expect(json_response["attributes"]["decayed-count"]).to eq(20)
+      expect(json_response["attributes"]["last-decay"]).to eq(Date.today.to_s)
+      expect(UserCounter.last.counter_name).to eq("tool_opens.kgp")
+      expect(UserCounter.last.count).to eq(20)
+      expect(UserCounter.last.decayed_count).to eq(20)
+      expect(UserCounter.last.last_decay).to eq(Date.today)
+    end
+
+    context "when user_counter exists" do
+      let!(:user_counter) { FactoryBot.create(:user_counter, user: user, counter_name: "tool_opens.kgp", count: 50, decayed_count: 50, last_decay: 90.days.ago) }
+
+      it "updates the count and decay" do
+        expect {
+          do_request data: {type: "user_counter", attributes: {increment: 20}}
+        }.to_not change { user_counter.count }
+
+        expect(status).to eq(200)
+        json_response = JSON.parse(response_body)["data"]
+        expect(json_response).not_to be_nil
+        expect(json_response["id"]).to eq("tool_opens.kgp")
+        expect(json_response["attributes"]["count"]).to eq(70)
+        expect((json_response["attributes"]["decayed-count"] - 45).abs).to be <= 0.004 # look within 0.004, close enough
+        expect(json_response["attributes"]["last-decay"]).to eq(Date.today.to_s)
+        expect(UserCounter.last.count).to eq(70)
+        # get close to 45 -- original value of 50 should decay to 25 with the 90 day half-life, then +20 from the patch count incremement
+        expect((UserCounter.last.decayed_count - 45).abs).to be <= 0.004
+        expect(UserCounter.last.last_decay).to eq(Date.today)
+      end
+    end
+  end
 end


### PR DESCRIPTION
As we are starting to flesh out more user related APIs, I want to organize all user endpoints under: `/user/me` with a future potential url pattern of `/user/:user_id` to run the APIs against other users.

I kept a copy of the update route at the old location for old versions of the GodTools Android app
