### PR TITLE
GT-1569 Add support for a required-android-version and required-ios-version property on content elements

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -242,9 +242,26 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="required-versions">
+                        <xs:annotation>
+                            <xs:documentation>The required-android-version and required-ios-version properties.
+
+                                Platform support:
+                                - Android Not Supported
+                                - iOS Not Supported
+                                - Web Not Applicable
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
         </xs:list>
+    </xs:simpleType>
+
+    <xs:simpleType name="version">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*" />
+        </xs:restriction>
     </xs:simpleType>
     <!-- endregion Value Definitions -->
 
@@ -281,6 +298,20 @@
             <xs:annotation>
                 <xs:documentation>This attributes specifies a list of required features in order for this element to be
                     rendered. By default no features are required to render an element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="required-android-version" type="content:version">
+            <xs:annotation>
+                <xs:documentation>This attribute specifies a minimum version of the android app in order for this
+                    element to be rendered. By default elements are rendered on all versions of Android.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="required-ios-version" type="content:version">
+            <xs:annotation>
+                <xs:documentation>This attribute specifies a minimum version of the android app in order for this
+                    element to be rendered. By default elements are rendered on all versions of Android.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/schema_tests/content/invalid/tests/text_required_android_version_invalid.xml
+++ b/schema_tests/content/invalid/tests/text_required_android_version_invalid.xml
@@ -1,0 +1,1 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" required-android-version="1.2-SNAPSHOT" />

--- a/schema_tests/content/invalid/tests/text_required_ios_version_invalid.xml
+++ b/schema_tests/content/invalid/tests/text_required_ios_version_invalid.xml
@@ -1,0 +1,1 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" required-ios-version="1.2-SNAPSHOT" />

--- a/schema_tests/content/valid/tests/text_required_versions.xml
+++ b/schema_tests/content/valid/tests/text_required_versions.xml
@@ -1,0 +1,2 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" required-android-version="1.2"
+    required-ios-version="2.3" />


### PR DESCRIPTION
```xml
<content:text required-android-version="6.0.1" />
<content:text required-ios-version="6.0.0" />
<content:text required-android-version="6.0.0" required-ios-version="5.9.0" />
```