### PR TITLE
GT-1569 Rename restrictTo to require-device-type

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -291,6 +291,15 @@
             <xs:annotation>
                 <xs:documentation>This attribute specifies that the element it is on is only rendered on the specified
                     device types. By default elements are rendered on all devices.
+
+                    This attribute was renamed to "required-device-type", this is currently being kept for backwards
+                    compatibility until it is safe to remove this attribute. This attribute can be removed after
+                    September 2023 depending on implementation status.
+
+                    Support status of "required-device-type":
+                    Android: Not Supported as of 6.0.1
+                    iOS: Not Supported as of 6.0.2
+                    Web: Not Supported
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -298,6 +307,13 @@
             <xs:annotation>
                 <xs:documentation>This attributes specifies a list of required features in order for this element to be
                     rendered. By default no features are required to render an element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="required-device-type" type="content:deviceTypes">
+            <xs:annotation>
+                <xs:documentation>This attribute specifies that the element it is on is only rendered on the specified
+                    device types. By default elements are rendered on all devices.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -326,8 +326,8 @@
         </xs:attribute>
         <xs:attribute name="required-ios-version" type="content:version">
             <xs:annotation>
-                <xs:documentation>This attribute specifies a minimum version of the android app in order for this
-                    element to be rendered. By default elements are rendered on all versions of Android.
+                <xs:documentation>This attribute specifies a minimum version of the iOS app in order for this
+                    element to be rendered. By default elements are rendered on all versions of iOS.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/schema_tests/tract/valid/tests/content_required_device_type.xml
+++ b/schema_tests/tract/valid/tests/content_required_device_type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<page xmlns="https://mobile-content-api.cru.org/xmlns/tract"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
+    <hero>
+        <content:paragraph>
+            <content:button type="url" url="https://www.example.com" required-device-type="web">
+                <content:text>Button</content:text>
+            </content:button>
+            <content:image resource="a.jpg" required-device-type="web" />
+            <content:text i18n-id="087b7293-70aa-41c7-b6cc-5d397a4eb41b" required-device-type="web mobile">God loves you and created you to know him personally.</content:text>
+            <content:paragraph required-device-type="mobile">
+                <content:text required-device-type="ios" />
+                <content:image resource="a.jpg" required-device-type="android" />
+            </content:paragraph>
+            <content:image resource="a.jpg" required-device-type="android web" />
+        </content:paragraph>
+    </hero>
+</page>


### PR DESCRIPTION
- rename restrictTo to required-device-type to match pattern of other content restriction attributes
- fix a typo in required-ios-version documentation
- add a test for the newly renamed required-device-type attribute
