### PR TITLE
Add CODECOV_TOKEN to avoid public API rate limits

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -50,6 +50,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codecov can resolve public GHA builds without needing a explicit token, but they accomplish this by using a shared github token that regularly hits rate limits.

to work around this the recommendation is to configure a `CODECOV_TOKEN` which allows codecov to utilize a separate github token associated with our codecov account that has separate rate limit tracking.