### PR TITLE
Downgrade redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,9 @@ gem "nokogiri"
 gem "oj", "~> 3.13.13"
 gem "ougai", "~> 2.0"
 gem "raddocs"
-gem "redis"
+# action cable currently requires redis < 5. This should be fixed in rails >= 7.0.4
+# relevant issue: https://github.com/redis/redis-rb/issues/1142
+gem "redis", "< 5"
 gem "rest-client", "~> 2.1.0"
 gem "rollbar"
 gem "rubyzip", ">= 1.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,6 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -327,10 +326,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.4)
-      redis-client (>= 0.7.4)
-    redis-client (0.8.0)
-      connection_pool
+    redis (4.8.0)
     regexp_parser (2.5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -503,7 +499,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 3.0)
   raddocs
   rails (~> 6.1.5)
-  redis
+  redis (< 5)
   rest-client (~> 2.1.0)
   rollbar
   rspec


### PR DESCRIPTION
redis 5.0 is currently not supported by the actioncable pubsub adapter.
