### PR TITLE
GT-1939 add the appropriate key to the `default_variant` serializer relationship

### DIFF
--- a/app/serializers/resource_serializer.rb
+++ b/app/serializers/resource_serializer.rb
@@ -16,7 +16,7 @@ class ResourceSerializer < ActiveModel::Serializer
   has_many :custom_manifests, key: "custom-manifests"
   has_many :variants, if: -> { object&.resource_type&.name == "metatool" }
   has_many :translated_attributes, key: "translated-attributes"
-  belongs_to :default_variant, if: -> { object&.resource_type&.name == "metatool" }
+  belongs_to :default_variant, key: "default-variant", if: -> { object&.resource_type&.name == "metatool" }
 
   def attributes(*args)
     hash = super

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -141,6 +141,7 @@ Destination.find_or_create_by!(service_type: :adobe_campaigns, url: "https://mc.
 # add metatool at the end because some tests depend upon resource ids
 metatool_resource = Resource.find_or_create_by!(name: "metatool", resource_type: metatool, abbreviation: "meta", system: godtools)
 kgp.update(metatool_id: metatool_resource.id)
+metatool_resource.update(default_variant_id: kgp.id)
 Resource.find_or_create_by!(name: "Knowing God Personally Variant", resource_type: tract,
   abbreviation: "kgp2", onesky_project_id: 148_314,
   system: godtools, total_views: 1268,

--- a/spec/acceptance/resources_controller_spec.rb
+++ b/spec/acceptance/resources_controller_spec.rb
@@ -70,11 +70,23 @@ resource "Resources" do
       expect(data["relationships"].keys).to eq ["system"]
     end
 
-    it "gets all resources with abbreviation" do
+    it "get resource with a specific abbreviation" do
       do_request "filter[abbreviation]": "es"
 
       expect(status).to be(200)
-      expect(JSON.parse(response_body)["data"].count).to be(1)
+      json = JSON.parse(response_body)
+      expect(json["data"].count).to be(1)
+      expect(json["data"][0]["attributes"]["abbreviation"]).to eq("es")
+    end
+
+    it "get resource with a specific abbreviation, include default-variant" do
+      do_request "filter[abbreviation]": "meta", include: "default-variant"
+
+      expect(status).to be(200)
+      json = JSON.parse(response_body)
+      expect(json["data"].count).to be(1)
+      expect(json["included"].count).to be(1)
+      expect(json["included"][0]["attributes"]["abbreviation"]).to eq("kgp")
     end
   end
 


### PR DESCRIPTION
without this, using `include=default-variant` doesn't include the relationship
