### PR TITLE
Remove the AppsFlyer analytics system from the content spec

### DIFF
--- a/public/xmlns/analytics.xsd
+++ b/public/xmlns/analytics.xsd
@@ -13,11 +13,6 @@
         <xs:list>
             <xs:simpleType>
                 <xs:restriction base="xs:token">
-                    <xs:enumeration value="appsflyer">
-                        <xs:annotation>
-                            <xs:documentation>AppsFlyer</xs:documentation>
-                        </xs:annotation>
-                    </xs:enumeration>
                     <xs:enumeration value="facebook">
                         <xs:annotation>
                             <xs:documentation>Facebook Analytics</xs:documentation>

--- a/schema_tests/lesson/valid/lessongs/01_title.xml
+++ b/schema_tests/lesson/valid/lessongs/01_title.xml
@@ -3,7 +3,7 @@
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content" listeners="replay-lesson">
 
     <analytics:events>
-        <analytics:event action="lessongodstory-0" system="appsflyer" />
+        <analytics:event action="lessongodstory-0" system="firebase" />
     </analytics:events>
 
     <content>

--- a/schema_tests/lesson/valid/tests/analytics_events.xml
+++ b/schema_tests/lesson/valid/tests/analytics_events.xml
@@ -1,6 +1,6 @@
 <page xmlns="https://mobile-content-api.cru.org/xmlns/lesson" xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics">
     <analytics:events>
-        <analytics:event action="event" system="appsflyer" trigger="visible" />
+        <analytics:event action="event" system="firebase" trigger="visible" />
     </analytics:events>
     <content />
 </page>

--- a/schema_tests/tract/valid/kgp/07_AttitudeOfYourHeart.xml
+++ b/schema_tests/tract/valid/kgp/07_AttitudeOfYourHeart.xml
@@ -28,7 +28,7 @@
                 <analytics:event action="kgp_gospel_presented" delay="8" system="firebase" trigger="visible">
                     <analytics:attribute key="cru.presentingthegospel" value="1"/>
                 </analytics:event>
-                <analytics:event action="gospel-presented" delay="8" system="appsflyer" trigger="visible" />
+                <analytics:event action="gospel-presented" delay="8" system="firebase" trigger="visible" />
             </analytics:events>
             <content:paragraph>
                 <content:text i18n-id="88a13a09-c5f6-4dd0-9fb3-88119738cf3c">Lord Jesus,</content:text>

--- a/schema_tests/tract/valid/tests/hero_analytics.xml
+++ b/schema_tests/tract/valid/tests/hero_analytics.xml
@@ -3,13 +3,13 @@
     xmlns="https://mobile-content-api.cru.org/xmlns/tract">
     <hero>
         <analytics:events>
-            <analytics:event action="event1" system="appsflyer">
+            <analytics:event action="event1" system="user">
                 <analytics:attribute key="a" value="1" />
             </analytics:event>
             <analytics:event action="event2" system="firebase">
                 <analytics:attribute key="a" value="2" />
             </analytics:event>
-            <analytics:event action="event3" system="appsflyer firebase">
+            <analytics:event action="event3" system="user firebase">
                 <analytics:attribute key="a" value="2" />
             </analytics:event>
         </analytics:events>


### PR DESCRIPTION
@aaronlaib I'm removing the AppsFlyer analytics system due to us no longer using AppsFlyer. This won't break existing tools, but will prevent you from saving updates to a page that contain AppsFlyer analytics events.