### PR TITLE
GT-2261 Support new xml filtering directives in the manifest and content xml

### DIFF
--- a/app/lib/xml_util.rb
+++ b/app/lib/xml_util.rb
@@ -3,9 +3,14 @@
 module XmlUtil
   XMLNS_CONTENT = "https://mobile-content-api.cru.org/xmlns/content"
   XMLNS_MANIFEST = "https://mobile-content-api.cru.org/xmlns/manifest"
+  XMLNS_PUBLISH = "https://mobile-content-api.cru.org/xmlns/publish"
   XMLNS_SHAREABLE = "https://mobile-content-api.cru.org/xmlns/shareable"
   XMLNS_TRACT = "https://mobile-content-api.cru.org/xmlns/tract"
   XMLNS_TRAINING = "https://mobile-content-api.cru.org/xmlns/training"
+
+  def self.filterable_nodes(xml)
+    xpath_namespace(xml, "//*[@publish:if-locale or @publish:if-locale-not]")
+  end
 
   def self.translatable_nodes(xml)
     xpath_namespace(xml, "//content:text[@i18n-id]")
@@ -24,7 +29,7 @@ module XmlUtil
   end
 
   def self.xpath_namespace(xml, string)
-    xml.xpath(string, "manifest" => XMLNS_MANIFEST, "content" => XMLNS_CONTENT, "shareable" => XMLNS_SHAREABLE, "tract" => XMLNS_TRACT, "training" => XMLNS_TRAINING)
+    xml.xpath(string, "manifest" => XMLNS_MANIFEST, "content" => XMLNS_CONTENT, "publish" => XMLNS_PUBLISH, "shareable" => XMLNS_SHAREABLE, "tract" => XMLNS_TRACT, "training" => XMLNS_TRAINING)
   end
 
   def self.get_or_create_child(xml, ns, name)

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Translation < ActiveRecord::Base
+  include Xml::Filterable
   include Xml::Translatable
 
   belongs_to :resource, touch: true
@@ -28,6 +29,7 @@ class Translation < ActiveRecord::Base
     phrases = download_translated_phrases(page.filename)
     xml = Nokogiri::XML(page_structure(page_id))
 
+    xml = filter_node_content(xml, self)
     xml = translate_node_content(xml, phrases, strict)
     xml = translate_node_attributes(xml, phrases, strict)
 
@@ -39,6 +41,7 @@ class Translation < ActiveRecord::Base
     phrases = download_translated_phrases("tip_#{tip.name}.json")
     xml = Nokogiri::XML(tip_structure(tip_id))
 
+    xml = filter_node_content(xml, self)
     xml = translate_node_content(xml, phrases, strict)
     xml = translate_node_attributes(xml, phrases, strict)
 

--- a/app/models/xml/filterable.rb
+++ b/app/models/xml/filterable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Xml
+  module Filterable
+    # Filters content in generated XML.
+    #
+    # @param xml [Nokorigi::XML] document
+    # @param translation [Translation] The translation object we are filtering node content for
+    # @return [Nokorigi::XML]
+    def filter_node_content(xml, translation)
+      locale = translation.language.code
+
+      XmlUtil.filterable_nodes(xml).each do |node|
+        if node.attribute_with_ns("if-locale", XmlUtil::XMLNS_PUBLISH)&.value&.split&.exclude? locale
+          node.unlink
+        elsif node.attribute_with_ns("if-locale-not", XmlUtil::XMLNS_PUBLISH)&.value&.split&.include? locale
+          node.unlink
+        end
+      end
+
+      xml
+    end
+  end
+end

--- a/app/models/xml/manifest.rb
+++ b/app/models/xml/manifest.rb
@@ -2,6 +2,7 @@
 
 module Xml
   class Manifest
+    include Filterable
     include Translatable
 
     attr_reader :document
@@ -15,6 +16,7 @@ module Xml
       manifest_node = @document.root
       add_manifest_metadata(manifest_node)
 
+      filter_node_content(@document, @translation)
       phrases = manifest_translated_phrases(manifest_node)
       translate_node_content(@document, phrases, true)
       translate_node_attributes(@document, phrases, true)

--- a/public/xmlns/article.xsd
+++ b/public/xmlns/article.xsd
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
-    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/article">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/publish" schemaLocation="publish.xsd" />
 
     <xs:complexType name="aemImport">
         <xs:attribute name="src" type="content:uri" />
     </xs:complexType>
     <xs:complexType name="categoryAemTag">
         <xs:attribute name="id" />
+        <xs:attributeGroup ref="publish:contentFiltering" />
     </xs:complexType>
 
     <!-- exported elements and element groups -->

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -258,6 +258,13 @@
         </xs:list>
     </xs:simpleType>
 
+    <xs:simpleType name="locale">
+        <xs:restriction base="xs:token">
+            <!-- language(-script)(-region) -->
+            <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-[a-zA-Z]{2}|-[0-9]{3})?" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="version">
         <xs:restriction base="xs:token">
             <xs:pattern value="[0-9]+(\.[0-9]+)*" />

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -264,6 +264,12 @@
             <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-[a-zA-Z]{2}|-[0-9]{3})?" />
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="locales">
+        <xs:annotation>
+            <xs:documentation>A space separated list of locales</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="content:locale" />
+    </xs:simpleType>
 
     <xs:simpleType name="version">
         <xs:restriction base="xs:token">

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
     xmlns:training="https://mobile-content-api.cru.org/xmlns/training" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/content">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/publish" schemaLocation="publish.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/training" schemaLocation="training.xsd" />
 
     <!-- region Value Definitions -->
@@ -297,6 +299,7 @@
 
         <xs:attributeGroup ref="content:contentRestrictions" />
         <xs:attributeGroup ref="content:visibilityAttributes" />
+        <xs:attributeGroup ref="publish:contentFiltering" />
     </xs:attributeGroup>
 
     <xs:attributeGroup name="contentRestrictions">
@@ -394,7 +397,7 @@
             <xs:documentation>Vertical stack of content with margin/padding on the top and bottom.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:group ref="content:elements" />
                 <xs:group ref="content:fixedSpacerOnly" />
             </xs:choice>
@@ -471,6 +474,7 @@
                         </xs:attribute>
 
                         <xs:attributeGroup ref="content:visibilityAttributes" />
+                        <xs:attributeGroup ref="publish:contentFiltering" />
                     </xs:complexType>
                 </xs:element>
 
@@ -992,10 +996,12 @@
                 the "followup:send" event and any other events triggered at the same time are prevented from firing.
             </xs:documentation>
         </xs:annotation>
-        <xs:choice maxOccurs="unbounded">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:group ref="content:elements" />
             <xs:group ref="content:fixedSpacerOnly" />
         </xs:choice>
+
+        <xs:attributeGroup ref="content:baseAttributes" />
     </xs:complexType>
     <!-- endregion form -->
 
@@ -1025,6 +1031,8 @@
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="value" type="xs:string" />
+
+        <xs:attributeGroup ref="content:baseAttributes" />
     </xs:complexType>
     <!-- endregion input -->
 
@@ -1078,6 +1086,8 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+
+            <xs:attributeGroup ref="content:baseAttributes" />
         </xs:complexType>
     </xs:element>
     <xs:group name="fixedSpacerOnly">
@@ -1092,6 +1102,8 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
+
+                    <xs:attributeGroup ref="content:baseAttributes" />
                 </xs:complexType>
             </xs:element>
         </xs:choice>

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -3,6 +3,7 @@
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
     xmlns:manifest="https://mobile-content-api.cru.org/xmlns/manifest"
     xmlns:page="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
     xmlns:shareable="https://mobile-content-api.cru.org/xmlns/shareable"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/manifest">
@@ -11,6 +12,7 @@
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/lesson" schemaLocation="lesson.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/page" schemaLocation="page.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/publish" schemaLocation="publish.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/shareable" schemaLocation="shareable.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/tract" schemaLocation="tract.xsd" />
 
@@ -183,6 +185,8 @@
                 <xs:documentation>The banner image to use for this category</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+
+        <xs:attributeGroup ref="publish:contentFiltering" />
     </xs:complexType>
 
     <xs:complexType name="page">

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -211,7 +211,7 @@
                 <xs:documentation>The code of the tool this manifest is for</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="locale" type="xs:token" use="optional">
+        <xs:attribute name="locale" type="content:locale" use="optional">
             <xs:annotation>
                 <xs:documentation>The language this manifest is for</xs:documentation>
             </xs:annotation>

--- a/public/xmlns/publish.xsd
+++ b/public/xmlns/publish.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/publish">
+
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+
+    <!-- region external attributes -->
+    <xs:attributeGroup name="contentFiltering">
+        <xs:annotation>
+            <xs:documentation>This attribute group is the set of attributes that can appear on elements to filter what
+                elements are published.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute ref="publish:if-locale">
+            <xs:annotation>
+                <xs:documentation>Only include the element this attribute is on when publishing in the listed locales.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="publish:if-locale-not">
+            <xs:annotation>
+                <xs:documentation>Only include the element this attribute is on when not publishing in the listed
+                    locales.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:attribute name="if-locale" type="content:locales" />
+    <xs:attribute name="if-locale-not" type="content:locales" />
+    <!-- endregion external attributes -->
+</xs:schema>

--- a/schema_tests/content/valid/tests/publish_filtering.xml
+++ b/schema_tests/content/valid/tests/publish_filtering.xml
@@ -1,0 +1,13 @@
+<content:paragraph xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
+    publish:if-locale="en" publish:if-locale-not="fr">
+    <content:spacer height="20" mode="fixed" publish:if-locale="en" publish:if-locale-not="fr" />
+    <content:text publish:if-locale="en" publish:if-locale-not="fr" />
+    <content:image resource="image.png" publish:if-locale="en" publish:if-locale-not="fr" />
+    <content:flow publish:if-locale="en">
+        <content:item publish:if-locale="en" />
+    </content:flow>
+    <content:form publish:if-locale="en">
+        <content:input name="name" publish:if-locale="en" />
+    </content:form>
+</content:paragraph>

--- a/schema_tests/manifest/invalid/tests/category_missing_label.xml
+++ b/schema_tests/manifest/invalid/tests/category_missing_label.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
-    xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content">
     <title>
         <content:text i18n-id="name">Knowing God Personally</content:text>

--- a/schema_tests/manifest/invalid/tests/category_publish_filtering_label.xml
+++ b/schema_tests/manifest/invalid/tests/category_publish_filtering_label.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish">
+    <title>
+        <content:text i18n-id="name">Knowing God Personally</content:text>
+    </title>
+
+    <categories>
+        <category id="test" banner="test.jpg">
+            <label>
+                <content:text publish:if-locale="en">Label</content:text>
+            </label>
+        </category>
+    </categories>
+</manifest>

--- a/schema_tests/manifest/invalid/tests/locale-lang.xml
+++ b/schema_tests/manifest/invalid/tests/locale-lang.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="lang">
+    <title>
+        <content:text i18n-id="name">Locale: lang</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/invalid/tests/locale-x.xml
+++ b/schema_tests/manifest/invalid/tests/locale-x.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="x">
+    <title>
+        <content:text i18n-id="name">Locale: x</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/locale-en.xml
+++ b/schema_tests/manifest/valid/tests/locale-en.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="en">
+    <title>
+        <content:text i18n-id="name">Locale: en</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/locale-fr-CA.xml
+++ b/schema_tests/manifest/valid/tests/locale-fr-CA.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="fr-CA">
+    <title>
+        <content:text i18n-id="name">Locale: fr-CA</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/locale-pap.xml
+++ b/schema_tests/manifest/valid/tests/locale-pap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="pap">
+    <title>
+        <content:text i18n-id="name">Locale: pap</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/locale-ru-143.xml
+++ b/schema_tests/manifest/valid/tests/locale-ru-143.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="ru-143">
+    <title>
+        <content:text i18n-id="name">Locale: ru-143</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/locale-zh-Hant.xml
+++ b/schema_tests/manifest/valid/tests/locale-zh-Hant.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content" locale="zh-Hant">
+    <title>
+        <content:text i18n-id="name">Locale: zh-Hant</content:text>
+    </title>
+</manifest>

--- a/schema_tests/manifest/valid/tests/publish_filtering.xml
+++ b/schema_tests/manifest/valid/tests/publish_filtering.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
+    xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish">
+    <title>
+        <content:text i18n-id="name">Questions About God</content:text>
+    </title>
+
+    <categories>
+        <category id="about-god" banner="about-god.jpg" publish:if-locale="en" publish:if-locale-not="fr">
+            <label>
+                <content:text>About God</content:text>
+            </label>
+            <article:aem-tag id="faith-topics:attributes-of-god/god-never-changes" publish:if-locale="en" publish:if-locale-not="fr" />
+            <article:aem-tag id="faith-topics:share-your-faith/testimony" />
+        </category>
+    </categories>
+</manifest>

--- a/spec/models/xml/manifest_spec.rb
+++ b/spec/models/xml/manifest_spec.rb
@@ -76,7 +76,7 @@ describe Xml::Manifest do
       expect(result.content).to eq(title)
     end
 
-    context "manifest with categories" do
+    context "with categories" do
       let(:title) { "Otázky o Bohu" }
       let(:translation) do
         t = Translation.find(1)
@@ -84,6 +84,7 @@ describe Xml::Manifest do
 <manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest"
           xmlns:article="https://mobile-content-api.cru.org/xmlns/article"
           xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+          xmlns:pub="https://mobile-content-api.cru.org/xmlns/publish"
           category-label-color="rgba(255,255,255,1)">
     <title><content:text i18n-id="name">Questions about God</content:text></title>
     <categories>
@@ -102,6 +103,26 @@ describe Xml::Manifest do
                <content:text i18n-id="about_life">About Life</content:text>
            </label>
         </category>
+        <category id="english-only" banner="english.jpg" pub:if-locale="en-AU en">
+           <label>
+               <content:text i18n-id="english-only" />
+           </label>
+        </category>
+        <category id="not-english" banner="not-english.jpg" pub:if-locale-not="en-AU en">
+           <label>
+               <content:text i18n-id="not-english" />
+           </label>
+        </category>
+        <category id="french-only" banner="french.jpg" pub:if-locale="fr">
+           <label>
+               <content:text i18n-id="french-only" />
+           </label>
+        </category>
+        <category id="not-french" banner="not-french.jpg" pub:if-locale-not="fr">
+           <label>
+               <content:text i18n-id="not-french" />
+           </label>
+        </category>
         <category id="everything" banner="missing.jpg">
            <label>
                <content:text i18n-id="everything">Everything</content:text>
@@ -117,6 +138,8 @@ describe Xml::Manifest do
           "about_god" => "O Bohu",
           "about_jesus" => "O Ježišovi",
           "about_life" => "O Živote",
+          "english-only" => "English Only",
+          "not-french" => "Not French",
           "everything" => "Všetko Ostatné"
         }
         allow(t).to(receive(:manifest_translated_phrases).and_return(phrases))
@@ -153,6 +176,15 @@ describe Xml::Manifest do
         result = XmlUtil.xpath_namespace(manifest.document, "//manifest:category/manifest:label/content:text")
         expect(result.first.content).to eq("O Bohu")
         expect(result.last.content).to eq("Všetko Ostatné")
+      end
+
+      it "filters categories based on locale publish attributes" do
+        result = XmlUtil.xpath_namespace(manifest.document, "//manifest:category")
+        expect(result.size).to eq(6)
+        expect(result[2][:id]).to eq("about-life")
+        expect(result[3][:id]).to eq("english-only")
+        expect(result[4][:id]).to eq("not-french")
+        expect(result[5][:id]).to eq("everything")
       end
 
       it "uses custom manifest structure when found" do


### PR DESCRIPTION
This PR adds support for a new `publish:if-locale="en"` and `publish:if-locale-not="en"` attributes that will filter published XML based on if you are publishing in the corresponding locale.

Sample XML:
```xml
<page
  xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
  xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish">
    <content:paragraph publish:if-locale="en">
        <!-- English only content -->
    </content:paragraph>
    <content:paragraph publish:if-locale-not="en">
        <!-- Content for languages other than English -->
    </content:paragraph>
</page>
```