### PR TITLE
GT-2290 Support a pagecollection page type

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -255,6 +255,17 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="page-collection">
+                        <xs:annotation>
+                            <xs:documentation>The cyoa page-collection page type.
+
+                                Platform support:
+                                - Android Not Supported
+                                - iOS Not Supported
+                                - Web Not Supported
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
         </xs:list>

--- a/public/xmlns/cyoa.xsd
+++ b/public/xmlns/cyoa.xsd
@@ -1,18 +1,37 @@
 <!-- Choose Your Own Adventure -->
-<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
-    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
+<xs:schema xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/cyoa">
 
-    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/page" schemaLocation="cyoa_pages.xsd" />
 
-    <xs:attribute name="parent" type="content:id" />
+    <xs:simpleType name="page-parent">
+        <xs:annotation>
+            <xs:documentation>parent page id with optional parameters</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <!-- Generic page -->
+            <xs:pattern value="[a-zA-Z0-9_.-]+" />
+            <!-- page-collection Page -->
+            <xs:pattern value="[a-zA-Z0-9_.-]+(\?active-page=[a-zA-Z0-9_.-]+)?" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:attribute name="parent" type="cyoa:page-parent" />
+    <xs:attribute name="parent_override_page-collection" type="cyoa:page-parent" />
 
     <xs:attributeGroup name="page">
         <xs:attribute ref="cyoa:parent">
             <xs:annotation>
                 <xs:documentation>This defines the parent of this page in a cyoa tool. This defaults to no parent page.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="cyoa:parent_override_page-collection">
+            <xs:annotation>
+                <xs:documentation>
+                    This provides a temporary override to the parent attribute when the page-collection feature is
+                    supported. This attribute will go away once page-collections are widely supported.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/public/xmlns/cyoa_pages.xsd
+++ b/public/xmlns/cyoa_pages.xsd
@@ -4,6 +4,7 @@
 
     <xs:include schemaLocation="page_content.xsd" />
     <xs:include schemaLocation="page_cardcollection.xsd" />
+    <xs:include schemaLocation="page_page-collection.xsd" />
 
     <xs:element name="page" type="page:BasePageType" />
 </xs:schema>

--- a/public/xmlns/page.xsd
+++ b/public/xmlns/page.xsd
@@ -5,4 +5,5 @@
     <xs:include schemaLocation="page_base.xsd" />
     <xs:include schemaLocation="page_cardcollection.xsd" />
     <xs:include schemaLocation="page_content.xsd" />
+    <xs:include schemaLocation="page_page-collection.xsd" />
 </xs:schema>

--- a/public/xmlns/page_base.xsd
+++ b/public/xmlns/page_base.xsd
@@ -32,8 +32,16 @@
 
         <xs:attribute name="listeners" type="content:listeners">
             <xs:annotation>
-                <xs:documentation>This is a list of event_ids that will cause navigation to jump to this page. Page
-                    listeners are always "active".
+                <xs:documentation>
+                    This is a list of event_ids that will cause navigation to jump to this page.
+
+                    - Page listeners are only "active" when the page collection containing them is active.
+                    - At this time the only defined page collections are a "pagecollection" page and the overall
+                      manifest.
+                    - If there are nested page collections, resolution should start with inner page collections and work
+                      out to the manifest as the final outer page collection to check.
+                    - If multiple pages have listeners that match a single event, only the first matched page should
+                      be triggered.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/public/xmlns/page_page-collection.xsd
+++ b/public/xmlns/page_page-collection.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:page="https://mobile-content-api.cru.org/xmlns/page" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/page">
+
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+    <xs:include schemaLocation="page_base.xsd" />
+    <xs:include schemaLocation="page_content.xsd" />
+
+    <xs:complexType name="page-collection">
+        <xs:annotation>
+            <xs:documentation>
+                A page collection can contains one or more content pages. These pages are presented as a swipeable
+                ViewPager.
+
+                The following attributes/elements are ignored for any children pages:
+                - cyoa:parent - For CYOA tools the parent attribute of the page collection is used for navigation and
+                                the parent attribute of any children pages is ignored.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="page:BasePageType">
+                <xs:sequence>
+                    <xs:element name="pages">
+                        <xs:complexType>
+                            <xs:choice maxOccurs="unbounded">
+                                <xs:element name="import">
+                                    <xs:complexType>
+                                        <xs:attribute name="filename" type="xs:string" use="required" />
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="page" type="page:BasePageType">
+                                    <xs:annotation>
+                                        <xs:documentation>This elements allows us to directly embed a content page in
+                                            the page collection xml.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:choice>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/schema_tests/cyoa/invalid/tests/page_page-collection_missing_page_type.xml
+++ b/schema_tests/cyoa/invalid/tests/page_page-collection_missing_page_type.xml
@@ -1,0 +1,18 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+    <pages>
+        <page>
+            <content>
+                <content:spacer />
+                <content:paragraph>
+                    <content:text>Text</content:text>
+                </content:paragraph>
+            </content>
+        </page>
+    </pages>
+</page>

--- a/schema_tests/cyoa/invalid/tests/page_page-collection_no_pages.xml
+++ b/schema_tests/cyoa/invalid/tests/page_page-collection_no_pages.xml
@@ -1,0 +1,7 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+</page>

--- a/schema_tests/cyoa/valid/tests/page_content_parent_path.xml
+++ b/schema_tests/cyoa/valid/tests/page_content_parent_path.xml
@@ -1,0 +1,7 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:cyoa="https://mobile-content-api.cru.org/xmlns/cyoa"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="content"
+    cyoa:parent="pagecollection?active-page=page2"
+    cyoa:parent_override_page-collection="pagecollection?active-page=page2">
+    <content />
+</page>

--- a/schema_tests/cyoa/valid/tests/page_page-collection.xml
+++ b/schema_tests/cyoa/valid/tests/page_page-collection.xml
@@ -1,0 +1,22 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+    <pages>
+        <import filename="other_page" />
+        <page xsi:type="content">
+            <analytics:events>
+                <analytics:event action="test" system="firebase" />
+            </analytics:events>
+            <content>
+                <content:spacer />
+                <content:paragraph>
+                    <content:text>Text</content:text>
+                </content:paragraph>
+            </content>
+        </page>
+    </pages>
+</page>


### PR DESCRIPTION
new XML:

page collection page
```xml
<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="page-collection" id="RG_page_collection">
    <analytics:events>
        <analytics:event action="test" system="firebase" />
    </analytics:events>
    <pages>
        <import filename="Gifts01.json" />
        <import filename="Gifts02.json" />
        <import filename="Gifts03.json" />
        <page xsi:type="content" id="embedded_page">
            <analytics:events>
                <analytics:event action="test" system="firebase" />
            </analytics:events>
            <content>
                <content:spacer />
                <content:paragraph>
                    <content:text>Text</content:text>
                </content:paragraph>
            </content>
        </page>
        <import filename="Gifts04.json" />
        <import filename="Gifts05.json" />
        <import filename="Gifts06.json" />
        <import filename="Gifts07.json" />
    </pages>
</page>
```

page parent updates
```xml
<!-- long term how parent pages can be specified to deep link to a specific page in a page collection -->
<page cyoa:parent="RG_page_collection?active-page=RG03" />

<!-- For backwards compatibility while we need to support older versions of the app that don't support page collections -->
<page cyoa:parent="RG03" cyoa:parent_override_page-collection="RG_page_collection?active-page=RG03" />
```

