### PR TITLE
GT-2529 Add support for a font-weight attribute on text elements

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -2,12 +2,14 @@
 <xs:schema xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
     xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
     xmlns:publish="https://mobile-content-api.cru.org/xmlns/publish"
-    xmlns:training="https://mobile-content-api.cru.org/xmlns/training" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:training="https://mobile-content-api.cru.org/xmlns/training"
+    xmlns:web="https://mobile-content-api.cru.org/xmlns/web" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/content">
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/analytics" schemaLocation="analytics.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/publish" schemaLocation="publish.xsd" />
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/training" schemaLocation="training.xsd" />
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/web" schemaLocation="web.xsd" />
 
     <!-- region Value Definitions -->
     <xs:simpleType name="colorValue">
@@ -666,6 +668,8 @@
                         <xs:documentation>Defines any typeface styles to apply to this text content.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+
+                <xs:attributeGroup ref="web:contentTextType" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -36,6 +36,13 @@
         <xs:restriction base="xs:string" />
     </xs:simpleType>
 
+    <xs:simpleType name="fontWeight">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1" />
+            <xs:maxInclusive value="1000" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="gravity">
         <xs:annotation>
             <xs:documentation>This type defines common gravity constants that determine how elements are positioned.
@@ -629,6 +636,11 @@
                 <xs:attribute name="i18n-id" type="xs:string">
                     <xs:annotation>
                         <xs:documentation>Defines the OneSky translation id for this text.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="font-weight" type="content:fontWeight">
+                    <xs:annotation>
+                        <xs:documentation>Defines the font-weight to use for this text.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="text-align" type="content:horizontalGravity" use="optional">

--- a/public/xmlns/web.xsd
+++ b/public/xmlns/web.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:web="https://mobile-content-api.cru.org/xmlns/web" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" targetNamespace="https://mobile-content-api.cru.org/xmlns/web">
+    <xs:annotation>
+        <xs:documentation>
+            This XML Schema contains all the defined web override attributes.
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
+
+    <!-- region: content:text attributes -->
+    <xs:attribute name="font-weight" type="content:fontWeight" />
+    <xs:attribute name="text-scale" type="xs:float" default="1.0" />
+
+    <xs:attributeGroup name="contentTextType">
+        <xs:attribute ref="web:font-weight" />
+        <xs:attribute ref="web:text-scale" />
+    </xs:attributeGroup>
+    <!-- endregion: content:text attributes -->
+</xs:schema>

--- a/schema_tests/content/invalid/tests/text_font_weight_invalid.xml
+++ b/schema_tests/content/invalid/tests/text_font_weight_invalid.xml
@@ -1,0 +1,1 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" font-weight="1001" />

--- a/schema_tests/content/valid/tests/text_font_weight.xml
+++ b/schema_tests/content/valid/tests/text_font_weight.xml
@@ -1,0 +1,1 @@
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" font-weight="1000" />

--- a/schema_tests/content/valid/tests/text_font_weight.xml
+++ b/schema_tests/content/valid/tests/text_font_weight.xml
@@ -1,1 +1,2 @@
-<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content" font-weight="1000" />
+<content:text xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:web="https://mobile-content-api.cru.org/xmlns/web" font-weight="1000" web:font-weight="1" />


### PR DESCRIPTION
- **add font-weight as a property for content:text elements**
- **provide web overrides for font-weight and text-scale attributes**
