### PR TITLE
GT-2535 Create web overrides for flow item width and row gravity

### DIFF
--- a/public/xmlns/content.xsd
+++ b/public/xmlns/content.xsd
@@ -501,6 +501,7 @@
 
                         <xs:attributeGroup ref="content:visibilityAttributes" />
                         <xs:attributeGroup ref="publish:contentFiltering" />
+                        <xs:attributeGroup ref="web:contentFlowItemElement" />
                     </xs:complexType>
                 </xs:element>
 
@@ -521,6 +522,7 @@
             </xs:attribute>
 
             <xs:attributeGroup ref="content:baseAttributes" />
+            <xs:attributeGroup ref="web:contentFlowElement" />
         </xs:complexType>
     </xs:element>
 

--- a/public/xmlns/web.xsd
+++ b/public/xmlns/web.xsd
@@ -10,9 +10,24 @@
 
     <xs:import namespace="https://mobile-content-api.cru.org/xmlns/content" schemaLocation="content.xsd" />
 
+    <!-- region: content:flow attributes -->
+    <xs:attribute name="item-width" type="content:dimension" />
+    <xs:attribute name="row-gravity" type="content:horizontalGravity" />
+    <xs:attribute name="width" type="content:dimension" />
+
+
+    <xs:attributeGroup name="contentFlowElement">
+        <xs:attribute ref="web:item-width" />
+        <xs:attribute ref="web:row-gravity" />
+    </xs:attributeGroup>
+    <xs:attributeGroup name="contentFlowItemElement">
+        <xs:attribute ref="web:width" />
+    </xs:attributeGroup>
+    <!-- endregion: content:flow attributes -->
+
     <!-- region: content:text attributes -->
     <xs:attribute name="font-weight" type="content:fontWeight" />
-    <xs:attribute name="text-scale" type="xs:float" default="1.0" />
+    <xs:attribute name="text-scale" type="xs:float" />
 
     <xs:attributeGroup name="contentTextType">
         <xs:attribute ref="web:font-weight" />

--- a/schema_tests/content/valid/tests/flow_mixed_items.xml
+++ b/schema_tests/content/valid/tests/flow_mixed_items.xml
@@ -1,4 +1,6 @@
-<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content" item-width="50%" row-gravity="center">
+<content:flow xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:web="https://mobile-content-api.cru.org/xmlns/web" item-width="50%" row-gravity="end" web:item-width="25%"
+    web:row-gravity="center">
     <content:spacer height="20" mode="fixed" />
     <content:item width="3">
         <content:text>Test</content:text>
@@ -9,7 +11,7 @@
     </content:paragraph>
     <content:item width="1%" />
     <content:item width="13%" />
-    <content:item width="100%" />
+    <content:item web:width="50%" width="100%" />
     <content:item width="1" />
     <content:item width="12345" />
 </content:flow>


### PR DESCRIPTION
```xml
<content:flow width="50%" web:width="25%" row-gravity="start" web:row-gravity="center">
  <content:item width="15" web:width="30" />
</content:flow>
```