### PR TITLE
GT-2573 add an optional header to card collection pages

### DIFF
--- a/public/xmlns/page_cardcollection.xsd
+++ b/public/xmlns/page_cardcollection.xsd
@@ -17,6 +17,9 @@
                         <xs:annotation>
                             <xs:documentation>
                                 This is header content shown above the cards pager.
+
+                                Default Styles:
+                                - text-align: center
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>

--- a/public/xmlns/page_cardcollection.xsd
+++ b/public/xmlns/page_cardcollection.xsd
@@ -13,6 +13,19 @@
         <xs:complexContent>
             <xs:extension base="page:BasePageType">
                 <xs:sequence>
+                    <xs:element name="header" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                This is header content shown above the cards pager.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:group ref="content:elements" />
+                                <xs:group ref="content:fixedSpacerOnly" />
+                            </xs:choice>
+                        </xs:complexType>
+                    </xs:element>
                     <xs:element name="cards">
                         <xs:complexType>
                             <xs:sequence maxOccurs="unbounded">

--- a/schema_tests/cyoa/valid/tests/page_cardcollection_header.xml
+++ b/schema_tests/cyoa/valid/tests/page_cardcollection_header.xml
@@ -1,0 +1,28 @@
+<page xmlns="https://mobile-content-api.cru.org/xmlns/page"
+    xmlns:analytics="https://mobile-content-api.cru.org/xmlns/analytics"
+    xmlns:content="https://mobile-content-api.cru.org/xmlns/content"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="cardcollection">
+    <analytics:events>
+        <analytics:event action="test" system="firebase" />
+    </analytics:events>
+    <header>
+        <content:spacer height="10" mode="fixed" />
+        <content:text>Header!</content:text>
+    </header>
+    <cards>
+        <card>
+            <content>
+                <content:spacer />
+                <content:paragraph>
+                    <content:text>Text</content:text>
+                </content:paragraph>
+            </content>
+        </card>
+        <card>
+            <analytics:events>
+                <analytics:event action="test" system="facebook" />
+            </analytics:events>
+            <content />
+        </card>
+    </cards>
+</page>


### PR DESCRIPTION
Sample page xml with a `<header>`: https://github.com/CruGlobal/mobile-content-api/pull/1779/files#diff-f687a435fce01c99755d1dac83f409892691c6487e39fc96060df8b3fd76111a

We support a full content stack in the header element, but be cautious adding too much content to the header