### PR TITLE
Skip database connection in staging for /monitors/lb endpoint

### DIFF
--- a/app/controllers/monitors_controller.rb
+++ b/app/controllers/monitors_controller.rb
@@ -5,8 +5,10 @@ class MonitorsController < ActionController::Base
   layout nil
 
   def lb
-    ActiveRecord::Migration.check_pending!
-    ActiveRecord::Base.connection.select_values("select id from systems limit 1")
+    unless Rails.env.staging?
+      ActiveRecord::Migration.check_pending!
+      ActiveRecord::Base.connection.select_values("select id from systems limit 1")
+    end
     render plain: File.read(Rails.public_path.join("lb.txt"))
   end
 


### PR DESCRIPTION
- Skip database connection checks in staging environment for /monitors/lb
endpoint
- Prepares staging environment for upcoming [Neon](https://neon.com/) database migration
- Will allow Neon to scale to zero during periods of inactivity by
preventing ALB health checks from keeping database connections active