### PR TITLE
use the test active_job queue adapter

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Use the test active_job queue adapter
+  config.active_job.queue_adapter = :test
+
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 


### PR DESCRIPTION
tests have been really flaky since the rails 7.1 upgrade, setting the active_job queue adapter to the test adapter seems to fix the issues from my limited local testing replaying a test seed that would pretty consistently fail for me before the config change.

see: https://discuss.rubyonrails.org/t/activerecord-7-1-test-failures/83928/13
see: https://github.com/rails/rails/issues/46797
