### PR TITLE
Add an error type to catch when uploading attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -30,7 +30,7 @@ class Attachment < ActiveRecord::Base
 
   def generate_sha256
     XmlUtil.filename_sha(URI.parse(url).open.read)
-  rescue NoMethodError, OpenURI::HTTPError, Errno::ECONNREFUSED
+  rescue NoMethodError, OpenURI::HTTPError, Errno::ECONNREFUSED, ArgumentError
     file = attachment_changes["file"].attachable
     file ||= url
     XmlUtil.filename_sha(File.read(file))


### PR DESCRIPTION
https://secure.helpscout.net/conversation/3097427240/1461072/

Rails 7.1 seems to be throwing a different type of error when trying to find the url of a file that's not attached yet.