### PR TITLE
GT-3034 Add resource checksums to published manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,33 @@ Multiple OAuth providers supported through service classes in `app/services/`:
 - Translation publishing handled by `PublishTranslationJob`
 - Redis configuration in `config/redis.yml`
 
+### Content Spec / XML Schemas
+
+XSD schemas defining the XML format for all tool content live in `public/xmlns/`. Base namespace: `https://mobile-content-api.cru.org/xmlns/`
+
+**Tool manifest**: `manifest.xsd` — defines resources and base styles included with a tool
+**Tool types**: `tract.xsd`, `lesson.xsd`, `article.xsd`, `cyoa.xsd`, `meta.xsd`
+**Page types**: `page.xsd`, `page_base.xsd`, `page_content.xsd`, `page_cardcollection.xsd`, `page_page-collection.xsd`, `cyoa_pages.xsd`
+**Shared**: `content.xsd`, `analytics.xsd`, `shareable.xsd`, `training.xsd`
+**Platform / publishing**: `web.xsd` (web rendering overrides), `publish.xsd` (publishing directives)
+
+Schema tests live in `schema_tests/{type}/valid/` and `schema_tests/{type}/invalid/`. Valid tests must pass `xmllint --schema`; invalid tests must fail it (enforced by `schema_tests/invalid.sh`). CI runs these automatically via GitHub Actions on every push/PR.
+
+To validate locally:
+```bash
+# Valid files must pass
+xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/tests/*.xml
+
+# Invalid files must fail
+./schema_tests/invalid.sh public/xmlns/manifest.xsd schema_tests/manifest/invalid/tests/*.xml
+```
+
 ### File Organization
 - `app/lib/` - Custom business logic (OneSky, XML utilities, analytics)
 - `app/services/` - Service objects for external integrations
 - `app/validators/` - Custom validation logic
 - `spec/acceptance/` - API integration tests
-- `schema_tests/` - XML schema validation tests
+- `schema_tests/` - XML schema validation tests (valid/ and invalid/ cases per schema type)
 
 ### Environment Requirements
 Key environment variables needed:
@@ -82,5 +103,4 @@ Key environment variables needed:
 
 ### Branch Strategy
 - Main branch: `master`
-- Current working branch: `rails71` (Rails 7.1 upgrade)
 - CI/CD runs on pushes to `master` and `staging` branches

--- a/app/lib/package.rb
+++ b/app/lib/package.rb
@@ -102,7 +102,7 @@ class Package
     document = Nokogiri::XML(translated_page)
     determine_resources(document)
     determine_tips(document) if include_tips?
-    checksum = XmlUtil.filename_sha(translated_page)
+    checksum = XmlUtil.sha256_hexdigest(translated_page)
     sha_filename = "#{checksum}.xml"
 
     File.write("#{@directory}/#{sha_filename}", translated_page)
@@ -114,7 +114,7 @@ class Package
     translated_tip = @translation.translated_tip(tip.id, true)
     document = Nokogiri::XML(translated_tip)
     determine_resources(document)
-    checksum = XmlUtil.filename_sha(translated_tip)
+    checksum = XmlUtil.sha256_hexdigest(translated_tip)
     sha_filename = "#{checksum}.xml"
 
     File.write("#{@directory}/#{sha_filename}", translated_tip)
@@ -148,7 +148,7 @@ class Package
   end
 
   def write_manifest_to_file(manifest)
-    filename = "#{XmlUtil.filename_sha(manifest.document.to_s)}.xml"
+    filename = "#{XmlUtil.sha256_hexdigest(manifest.document.to_s)}.xml"
     @translation.manifest_name = filename
 
     file = File.open("#{@directory}/#{filename}", "w")

--- a/app/lib/package.rb
+++ b/app/lib/package.rb
@@ -81,9 +81,9 @@ class Package
     @translation.resource.pages.order(position: :asc).each do |page|
       Rails.logger.info("Adding page with id: #{page.id} to package for translation with id: #{@translation.id}")
 
-      sha_filename = write_page_to_file(page)
+      sha_filename, checksum, size = write_page_to_file(page)
       add_file_to_zip_and_s3(zip_file, sha_filename, "#{@directory}/#{sha_filename}")
-      manifest.add_page(page.filename, sha_filename)
+      manifest.add_page(page.filename, sha_filename, checksum: checksum, size: size)
     end
   end
 
@@ -91,9 +91,9 @@ class Package
     @tips.uniq.each do |tip|
       Rails.logger.info("Adding tip with id: #{tip.id} to package for translation with id: #{@translation.id}")
 
-      sha_filename = write_tip_to_file(tip)
+      sha_filename, checksum, size = write_tip_to_file(tip)
       add_file_to_zip_and_s3(zip_file, sha_filename, "#{@directory}/#{sha_filename}")
-      manifest.add_tip(tip.name, sha_filename)
+      manifest.add_tip(tip.name, sha_filename, checksum: checksum, size: size)
     end
   end
 
@@ -102,22 +102,24 @@ class Package
     document = Nokogiri::XML(translated_page)
     determine_resources(document)
     determine_tips(document) if include_tips?
-    sha_filename = XmlUtil.xml_filename_sha(translated_page)
+    checksum = XmlUtil.filename_sha(translated_page)
+    sha_filename = "#{checksum}.xml"
 
     File.write("#{@directory}/#{sha_filename}", translated_page)
 
-    sha_filename
+    [sha_filename, checksum, translated_page.bytesize]
   end
 
   def write_tip_to_file(tip)
     translated_tip = @translation.translated_tip(tip.id, true)
     document = Nokogiri::XML(translated_tip)
     determine_resources(document)
-    sha_filename = XmlUtil.xml_filename_sha(translated_tip)
+    checksum = XmlUtil.filename_sha(translated_tip)
+    sha_filename = "#{checksum}.xml"
 
     File.write("#{@directory}/#{sha_filename}", translated_tip)
 
-    sha_filename
+    [sha_filename, checksum, translated_tip.bytesize]
   end
 
   def add_attachments(zip_file, manifest)
@@ -127,9 +129,9 @@ class Package
       Rails.logger.info("Adding attachment with id: #{attachment.id} to package " \
                         "for translation with id: #{@translation.id}")
 
-      sha_filename = save_attachment_to_file(attachment)
+      sha_filename, checksum, size = save_attachment_to_file(attachment)
       add_file_to_zip_and_s3(zip_file, sha_filename, "#{@directory}/#{sha_filename}")
-      manifest.add_resource(attachment.filename, sha_filename)
+      manifest.add_resource(attachment.filename, sha_filename, checksum: checksum, size: size)
     end
   end
 
@@ -142,11 +144,11 @@ class Package
     sha_with_ext_filename = attachment.sha256 + File.extname(attachment.url)
 
     File.binwrite("#{@directory}/#{sha_with_ext_filename}", string_io_bytes)
-    sha_with_ext_filename
+    [sha_with_ext_filename, attachment.sha256, string_io_bytes.bytesize]
   end
 
   def write_manifest_to_file(manifest)
-    filename = XmlUtil.xml_filename_sha(manifest.document.to_s)
+    filename = "#{XmlUtil.filename_sha(manifest.document.to_s)}.xml"
     @translation.manifest_name = filename
 
     file = File.open("#{@directory}/#{filename}", "w")

--- a/app/lib/xml_util.rb
+++ b/app/lib/xml_util.rb
@@ -20,7 +20,7 @@ module XmlUtil
     xml.xpath("//@*[contains(name(),'-i18n-id')]")
   end
 
-  def self.filename_sha(data)
+  def self.sha256_hexdigest(data)
     Digest::SHA256.hexdigest(data)
   end
 

--- a/app/lib/xml_util.rb
+++ b/app/lib/xml_util.rb
@@ -20,10 +20,6 @@ module XmlUtil
     xml.xpath("//@*[contains(name(),'-i18n-id')]")
   end
 
-  def self.xml_filename_sha(data)
-    "#{filename_sha(data)}.xml"
-  end
-
   def self.filename_sha(data)
     Digest::SHA256.hexdigest(data)
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -29,11 +29,11 @@ class Attachment < ActiveRecord::Base
   end
 
   def generate_sha256
-    XmlUtil.filename_sha(URI.parse(url).open.read)
+    XmlUtil.sha256_hexdigest(URI.parse(url).open.read)
   rescue NoMethodError, OpenURI::HTTPError, Errno::ECONNREFUSED, ArgumentError
     file = attachment_changes["file"].attachable
     file ||= url
-    XmlUtil.filename_sha(File.read(file))
+    XmlUtil.sha256_hexdigest(File.read(file))
   end
 
   private

--- a/app/models/xml/manifest.rb
+++ b/app/models/xml/manifest.rb
@@ -22,16 +22,16 @@ module Xml
       translate_node_attributes(@document, phrases, true)
     end
 
-    def add_page(filename, sha_filename)
-      pages_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "page", filename, sha_filename))
+    def add_page(filename, sha_filename, checksum: nil, size: nil)
+      pages_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "page", filename, sha_filename, checksum: checksum, size: size))
     end
 
-    def add_tip(name, sha_filename)
-      tips_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "tip", name, sha_filename, "id"))
+    def add_tip(name, sha_filename, checksum: nil, size: nil)
+      tips_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "tip", name, sha_filename, "id", checksum: checksum, size: size))
     end
 
-    def add_resource(filename, sha_filename)
-      resources_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "resource", filename, sha_filename))
+    def add_resource(filename, sha_filename, checksum: nil, size: nil)
+      resources_node.add_child(create_file_node(XmlUtil::XMLNS_MANIFEST, "resource", filename, sha_filename, checksum: checksum, size: size))
     end
 
     private
@@ -84,10 +84,12 @@ module Xml
       @resources = XmlUtil.get_or_create_child(@document.root, XmlUtil::XMLNS_MANIFEST, "resources")
     end
 
-    def create_file_node(namespace, type, filename, sha_filename, filename_key = "filename")
+    def create_file_node(namespace, type, filename, sha_filename, filename_key = "filename", checksum: nil, size: nil)
       node = @document.create_element(type, xmlns: namespace)
       node[filename_key] = filename
       node["src"] = sha_filename
+      node["checksum-sha256"] = checksum if checksum
+      node["size"] = size.to_s if size
       node
     end
   end

--- a/public/xmlns/manifest.xsd
+++ b/public/xmlns/manifest.xsd
@@ -50,6 +50,32 @@
         </xs:documentation>
     </xs:annotation>
 
+    <xs:attributeGroup name="resourceChecksums">
+        <xs:annotation>
+            <xs:documentation>Integrity attributes for a referenced resource file. These allow clients to verify the
+                integrity and size of a downloaded resource without having to open or process it.
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="checksum-sha256">
+            <xs:annotation>
+                <xs:documentation>SHA-256 checksum of the resource file, encoded as 64 hex characters.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value="[a-fA-F0-9]{64}" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+
+        <xs:attribute name="size" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>Size of the resource file in bytes.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
     <xs:simpleType name="toolType">
         <xs:restriction base="xs:token">
             <xs:enumeration value="article" />
@@ -81,6 +107,7 @@
                                 <xs:complexType>
                                     <xs:attribute name="filename" type="xs:string" />
                                     <xs:attribute name="src" type="xs:string" use="required" />
+                                    <xs:attributeGroup ref="manifest:resourceChecksums" />
                                 </xs:complexType>
                             </xs:element>
 
@@ -95,6 +122,7 @@
                                 <xs:complexType>
                                     <xs:attribute name="filename" type="xs:string" use="required" />
                                     <xs:attribute name="src" type="xs:string" use="required" />
+                                    <xs:attributeGroup ref="manifest:resourceChecksums" />
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
@@ -107,6 +135,7 @@
                                 <xs:complexType>
                                     <xs:attribute name="id" type="content:id" use="required" />
                                     <xs:attribute name="src" type="xs:string" use="required" />
+                                    <xs:attributeGroup ref="manifest:resourceChecksums" />
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/schema_tests/manifest/invalid/tests/resource_checksum_sha256_invalid_chars.xml
+++ b/schema_tests/manifest/invalid/tests/resource_checksum_sha256_invalid_chars.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    <resources>
+        <resource filename="hero.jpg" src="https://example.com/hero.jpg"
+            checksum-sha256="g1h2i3j4k5l6g1h2i3j4k5l6g1h2i3j4k5l6g1h2i3j4k5l6g1h2i3j4k5l6g1h2" />
+    </resources>
+</manifest>

--- a/schema_tests/manifest/invalid/tests/resource_checksum_sha256_invalid_length.xml
+++ b/schema_tests/manifest/invalid/tests/resource_checksum_sha256_invalid_length.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    <resources>
+        <resource filename="hero.jpg" src="https://example.com/hero.jpg"
+            checksum-sha256="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1" />
+    </resources>
+</manifest>

--- a/schema_tests/manifest/valid/tests/resource_checksums.xml
+++ b/schema_tests/manifest/valid/tests/resource_checksums.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+    <pages>
+        <page src="01_home.xml"
+            checksum-sha256="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+            size="4096" />
+    </pages>
+    <resources>
+        <resource filename="hero_lower.jpg" src="https://example.com/hero_lower.jpg"
+            checksum-sha256="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            size="102400" />
+        <resource filename="hero_upper.jpg" src="https://example.com/hero_upper.jpg"
+            checksum-sha256="A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
+            size="102400" />
+    </resources>
+    <tips>
+        <tip id="tip1" src="tip1.xml"
+            checksum-sha256="0f1e2d3c4b5a6978869504130211f0e1d2c3b4a5968778695041302110f1e2d3"
+            size="2048" />
+    </tips>
+</manifest>

--- a/spec/models/xml/manifest_spec.rb
+++ b/spec/models/xml/manifest_spec.rb
@@ -14,29 +14,45 @@ describe Xml::Manifest do
   end
 
   context "manifest" do
+    let(:page1_sha) { "790a2170adb13955e67dee0261baff93cc7f045b22a35ad434435bdbdcec036a" }
+    let(:page2_sha) { "5ce1cd1be598eb31a76c120724badc90e1e9bafa4b03c33ce40f80ccff756444" }
+    let(:tip_sha) { "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd" }
+    let(:resource_sha) { "073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd" }
+
     let(:pages) do
-      Nokogiri::XML('<pages xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <page filename="04_ThirdPoint.xml" src="790a2170adb13955e67dee0261baff93cc7f045b22a35ad434435bdbdcec036a.xml"/>
-        <page filename="13_FinalPage.xml" src="5ce1cd1be598eb31a76c120724badc90e1e9bafa4b03c33ce40f80ccff756444.xml"/>
-      </pages>').root
+      Nokogiri::XML(<<~XML).root
+        <pages xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <page filename="04_ThirdPoint.xml" src="#{page1_sha}.xml"
+                checksum-sha256="#{page1_sha}" size="1024"/>
+          <page filename="13_FinalPage.xml" src="#{page2_sha}.xml"
+                checksum-sha256="#{page2_sha}" size="2048"/>
+        </pages>
+      XML
     end
     let(:tips) do
-      Nokogiri::XML('<tips xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <tip id="tip_name" src="kt6SxuuCU5M8AYmqpGjcWNNYCiCipEauybniinC5HrhF6h6KOvEZo8f5UhQUnRd.xml"/>
-      </tips>').root
+      Nokogiri::XML(<<~XML).root
+        <tips xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <tip id="tip_name" src="kt6SxuuCU5M8AYmqpGjcWNNYCiCipEauybniinC5HrhF6h6KOvEZo8f5UhQUnRd.xml"
+               checksum-sha256="#{tip_sha}" size="512"/>
+        </tips>
+      XML
     end
     let(:resources) do
-      Nokogiri::XML('<resources xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <resource filename="wall.jpg" src="073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd"/>
-      </resources>').root
+      Nokogiri::XML(<<~XML).root
+        <resources xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <resource filename="wall.jpg" src="#{resource_sha}"
+                    checksum-sha256="#{resource_sha}" size="65536"/>
+        </resources>
+      XML
     end
 
     let(:manifest) do
       m = described_class.new(translation)
-      m.add_page("04_ThirdPoint.xml", "790a2170adb13955e67dee0261baff93cc7f045b22a35ad434435bdbdcec036a.xml")
-      m.add_page("13_FinalPage.xml", "5ce1cd1be598eb31a76c120724badc90e1e9bafa4b03c33ce40f80ccff756444.xml")
-      m.add_tip("tip_name", "kt6SxuuCU5M8AYmqpGjcWNNYCiCipEauybniinC5HrhF6h6KOvEZo8f5UhQUnRd.xml")
-      m.add_resource("wall.jpg", "073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd")
+      m.add_page("04_ThirdPoint.xml", "#{page1_sha}.xml", checksum: page1_sha, size: 1024)
+      m.add_page("13_FinalPage.xml", "#{page2_sha}.xml", checksum: page2_sha, size: 2048)
+      m.add_tip("tip_name", "kt6SxuuCU5M8AYmqpGjcWNNYCiCipEauybniinC5HrhF6h6KOvEZo8f5UhQUnRd.xml",
+        checksum: tip_sha, size: 512)
+      m.add_resource("wall.jpg", resource_sha, checksum: resource_sha, size: 65536)
       m
     end
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -192,26 +192,46 @@ describe Package do
 
   context "manifest" do
     let(:pages) do
-      Nokogiri::XML('<pages xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <page filename="04_ThirdPoint.xml" src="ec9bac08c42c571a4df305171d04e196a5601af87e664600f1afba820b2a1a59.xml"/>
-        <page filename="13_FinalPage.xml" src="e9a07c177bb189cb1665307fffd770ad7c52316e0284a38fb8fa42f436b29397.xml"/>
-      </pages>').root
+      Nokogiri::XML(<<~XML).root
+        <pages xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <page filename="04_ThirdPoint.xml"
+                src="ec9bac08c42c571a4df305171d04e196a5601af87e664600f1afba820b2a1a59.xml"
+                checksum-sha256="ec9bac08c42c571a4df305171d04e196a5601af87e664600f1afba820b2a1a59"
+                size="1181"/>
+          <page filename="13_FinalPage.xml"
+                src="e9a07c177bb189cb1665307fffd770ad7c52316e0284a38fb8fa42f436b29397.xml"
+                checksum-sha256="e9a07c177bb189cb1665307fffd770ad7c52316e0284a38fb8fa42f436b29397"
+                size="1621"/>
+        </pages>
+      XML
     end
     let(:resources) do
-      Nokogiri::XML('<resources xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <resource filename="web_bundled.png" src="d028ba4dc56eb5ac641f19eeca5baa25d748ab303b32a5580f601e112a19b9f5.png"/>
-        <resource filename="web_attach.png" src="97c82df868bcd36afcb4b0af912a06c93782d47e9edc35604d9a4dc31afb0e47.png"/>
-        <resource filename="mobile_only.png" src="2cf2ab68c49b217c6b2402699c742a236f96efe36bc48821eb6ba1a1427b8945.png"/>
-        <resource filename="web_mobile.png" src="4245551d69a8c582b6fc5185fb5312efc4f6863bda991a12a76102736f92fa2d.png"/>
-        <resource filename="both.png" src="ad03ee4cc7b015919b375539db150dee5f47245c6a293663c21c774b2dba294f.png"/>
-        <resource filename="wall.jpg" src="073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd.jpg"/>
-      </resources>').root
+      Nokogiri::XML(<<~XML).root
+        <resources xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <resource filename="web_bundled.png" src="d028ba4dc56eb5ac641f19eeca5baa25d748ab303b32a5580f601e112a19b9f5.png"
+                    checksum-sha256="d028ba4dc56eb5ac641f19eeca5baa25d748ab303b32a5580f601e112a19b9f5" size="4108"/>
+          <resource filename="web_attach.png" src="97c82df868bcd36afcb4b0af912a06c93782d47e9edc35604d9a4dc31afb0e47.png"
+                    checksum-sha256="97c82df868bcd36afcb4b0af912a06c93782d47e9edc35604d9a4dc31afb0e47" size="5853"/>
+          <resource filename="mobile_only.png" src="2cf2ab68c49b217c6b2402699c742a236f96efe36bc48821eb6ba1a1427b8945.png"
+                    checksum-sha256="2cf2ab68c49b217c6b2402699c742a236f96efe36bc48821eb6ba1a1427b8945" size="4166"/>
+          <resource filename="web_mobile.png" src="4245551d69a8c582b6fc5185fb5312efc4f6863bda991a12a76102736f92fa2d.png"
+                    checksum-sha256="4245551d69a8c582b6fc5185fb5312efc4f6863bda991a12a76102736f92fa2d" size="5266"/>
+          <resource filename="both.png" src="ad03ee4cc7b015919b375539db150dee5f47245c6a293663c21c774b2dba294f.png"
+                    checksum-sha256="ad03ee4cc7b015919b375539db150dee5f47245c6a293663c21c774b2dba294f" size="2413"/>
+          <resource filename="wall.jpg" src="073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd.jpg"
+                    checksum-sha256="073d78ef4dc421f10d2db375414660d3983f506fabdaaff0887f6ee955aa3bdd" size="23688"/>
+        </resources>
+      XML
     end
     let(:tips) do
-      Nokogiri::XML('<tips xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
-        <tip id="tip1" src="c26f707f414bbfda0656d890867d7da90058d8d0303dce8daef80951760cd56d.xml"/>
-        <tip id="tip2" src="503fa579c48f89d3e7428e3a3f24fae80b43bf97b53318309696a093298ae032.xml"/>
-      </tips>').root
+      Nokogiri::XML(<<~XML).root
+        <tips xmlns="https://mobile-content-api.cru.org/xmlns/manifest">
+          <tip id="tip1" src="c26f707f414bbfda0656d890867d7da90058d8d0303dce8daef80951760cd56d.xml"
+               checksum-sha256="c26f707f414bbfda0656d890867d7da90058d8d0303dce8daef80951760cd56d" size="393"/>
+          <tip id="tip2" src="503fa579c48f89d3e7428e3a3f24fae80b43bf97b53318309696a093298ae032.xml"
+               checksum-sha256="503fa579c48f89d3e7428e3a3f24fae80b43bf97b53318309696a093298ae032" size="508"/>
+        </tips>
+      XML
     end
     let(:title) { "this is the kgp" }
 
@@ -245,7 +265,7 @@ describe Package do
         push
 
         result = XmlUtil.xpath_namespace(load_xml(translation.manifest_name), "//manifest:tips").first
-        expect(result).to_not be_equivalent_to(tips)
+        expect(result).to be_nil
         verify_s3_uploads_match_zip
       end
     end


### PR DESCRIPTION
## Summary

- Adds `resourceChecksums` attributeGroup to `manifest.xsd` with `checksum-sha256` (64-char hex) and `size` (bytes) attributes for pages, resources, and tips
- Updates the package build process to compute and set these attributes on every manifest entry
- Adds XSD schema tests (valid/invalid) for the new attributeGroup
- Removes unused `XmlUtil.xml_filename_sha` and renames `filename_sha` → `sha256_hexdigest`

## Test plan

- [ ] Run `bundle exec rspec spec/models/xml/manifest_spec.rb spec/package_spec.rb`
- [ ] Run XSD schema tests: `xmllint --schema public/xmlns/manifest.xsd --noout schema_tests/manifest/valid/tests/*.xml` and `./schema_tests/invalid.sh public/xmlns/manifest.xsd schema_tests/manifest/invalid/tests/*.xml`
- [ ] Publish a translation and verify the manifest contains `checksum-sha256` and `size` on page, resource, and tip entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)